### PR TITLE
Fix typo in a README

### DIFF
--- a/examples/hot-reload/README.md
+++ b/examples/hot-reload/README.md
@@ -7,7 +7,7 @@ cargo watch -s "cargo build --lib"
 
 in second terminal:
 ```
-cagro run
+cargo run
 ```
 
 NOTE: you will get a segfault if you change the `AppData`


### PR DESCRIPTION
Pretty sure cagro run isn't a real command. Just sayin'