### PR TITLE
Make dropdown windows able to be sized

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ hot-reload = ["libloading", "notify5", "rand"]
 
 [dependencies.druid]
 git = "https://github.com/linebender/druid"
-rev = "d846cc2" # update this when upgrading to newer druid
+rev = "3661030" # update this when upgrading to newer druid
 # and update examples/hot_reload/Cargo.toml as well
 
 [dependencies]

--- a/examples/dropdown.rs
+++ b/examples/dropdown.rs
@@ -1,5 +1,5 @@
 use druid::widget::{
-    Button, CrossAxisAlignment, Flex, Label, RadioGroup, Scroll, TextBox, WidgetExt,
+    Button, CrossAxisAlignment, Flex, Label, RadioGroup, Scroll, SizedBox, TextBox, WidgetExt,
 };
 use druid::{AppLauncher, Data, Env, EventCtx, Lens, Widget, WindowDesc};
 use druid_widget_nursery::{Dropdown, DROP};
@@ -68,7 +68,7 @@ fn main_widget() -> impl Widget<DropDownState> {
             )
             .with_spacer(200.)
             .with_child(
-                Dropdown::new(
+                Dropdown::new_sized(
                     Button::new(|f: &Fruit, _: &Env| format!("{:?}", f))
                         .on_click(|ctx: &mut EventCtx, _, _| ctx.submit_notification(DROP)),
                     |_, _| {
@@ -78,6 +78,7 @@ fn main_widget() -> impl Widget<DropDownState> {
                             ("Orange", Fruit::Orange),
                         ])
                     },
+                    druid::Size::new(100., 400.)
                 )
                 .align_left()
                 .lens(DropDownState::fruit),

--- a/examples/hot-reload/Cargo.toml
+++ b/examples/hot-reload/Cargo.toml
@@ -12,4 +12,4 @@ druid-widget-nursery = { path = "../..", features = ["hot-reload"] }
 
 [dependencies.druid]
 git = "https://github.com/linebender/druid"
-rev = "d846cc2" # update this when upgrading to newer druid
+rev = "3661030" # update this when upgrading to newer druid

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -42,7 +42,7 @@ struct AppData {
 fn main_widget() -> impl Widget<AppData> {
     let mut row = Flex::row().cross_axis_alignment(CrossAxisAlignment::Start);
     row.add_flex_child(
-        Scroll::new(ListSelect::build_widget(vec![
+        Scroll::new(ListSelect::new(vec![
             ("to Sydney", Destination::Sydney),
             ("to Petaluma", Destination::Petaluma),
             ("to Tokyo", Destination::Tokyo),
@@ -54,7 +54,7 @@ fn main_widget() -> impl Widget<AppData> {
     );
     row.add_default_spacer();
     row.add_flex_child(
-        DropdownSelect::build_widget(vec![
+        DropdownSelect::new(vec![
             ("by car", Transportation::Car),
             ("by train", Transportation::Train),
             ("by plane", Transportation::Plane),

--- a/src/dropdown.rs
+++ b/src/dropdown.rs
@@ -1,7 +1,10 @@
-use druid::commands::CLOSE_WINDOW;
 use druid::widget::prelude::*;
 use druid::widget::WidgetExt;
 use druid::WindowSizePolicy;
+use druid::{
+    commands::CLOSE_WINDOW,
+    widget::{Scroll, SizedBox},
+};
 use druid::{Point, Selector, WindowConfig};
 use druid::{WindowId, WindowLevel};
 
@@ -21,6 +24,23 @@ impl<T: Data> Dropdown<T> {
         Dropdown {
             header: header.boxed(),
             drop: Box::new(move |d, e| make_drop(d, e).boxed()),
+            window: None,
+        }
+    }
+
+    pub fn new_sized<DW: Widget<T> + 'static>(
+        header: impl Widget<T> + 'static,
+        make_drop: impl Fn(&T, &Env) -> DW + 'static,
+        size: Size,
+    ) -> Dropdown<T> {
+        Dropdown {
+            header: header.boxed(),
+            drop: Box::new(move |d, e| {
+                SizedBox::new(Scroll::new(make_drop(d, e)))
+                    .width(size.width)
+                    .height(size.height)
+                    .boxed()
+            }),
             window: None,
         }
     }

--- a/src/list_select.rs
+++ b/src/list_select.rs
@@ -32,7 +32,7 @@ pub struct ListSelect<T> {
 
 impl<T: Data + PartialEq> ListSelect<T> {
     /// Given a vector of `(label_text, enum_variant)` tuples, create a list of items to select from
-    pub fn build_widget(
+    pub fn new(
         values: impl IntoIterator<Item = (impl Into<LabelText<T>> + 'static, T)>,
     ) -> impl Widget<T> {
         let mut col = Flex::column().cross_axis_alignment(CrossAxisAlignment::Start);


### PR DESCRIPTION
Previously, if a dropdown window was smaller than its contents, the contents was not fully showed.

I added `new_sized` methods for `Dropdown` and `DropdownSelect` which specify a size of the dropdown windows, so that the windows can be scrolled when the contents is bigger than the windows.