### PR TITLE
New progress bar

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ hot-reload = ["libloading", "notify5", "rand"]
 
 [dependencies.druid]
 git = "https://github.com/linebender/druid"
-rev = "3661030" # update this when upgrading to newer druid
+rev = "75e83ae" # update this when upgrading to newer druid
 # and update examples/hot_reload/Cargo.toml as well
 
 [dependencies]

--- a/examples/hot-reload/Cargo.toml
+++ b/examples/hot-reload/Cargo.toml
@@ -12,4 +12,4 @@ druid-widget-nursery = { path = "../..", features = ["hot-reload"] }
 
 [dependencies.druid]
 git = "https://github.com/linebender/druid"
-rev = "3661030" # update this when upgrading to newer druid
+rev = "75e83ae" # update this when upgrading to newer druid

--- a/examples/progress_bar.rs
+++ b/examples/progress_bar.rs
@@ -1,3 +1,4 @@
+use druid::piet::GradientStop;
 use druid::widget::{
     Button, CrossAxisAlignment, EnvScope, Flex, Label, List, MainAxisAlignment, Padding as Pad,
     TextBox, WidgetExt,
@@ -124,6 +125,55 @@ fn build_ui() -> impl Widget<AppState> {
                     .with_corner_radius(2.0)
                     .with_border_width(2.0)
                     .lens(AppState::leaping_progress),
+            ),
+    );
+    flex.add_spacer(10.0);
+    flex.add_child(
+        Flex::column()
+            .with_child(Label::new("Fixed Gradient Progress Bar"))
+            .with_child(
+                ProgressBar::new()
+                    .with_bar_brush(piet::PaintBrush::Linear(druid::LinearGradient::new(
+                        UnitPoint::LEFT,
+                        UnitPoint::RIGHT,
+                        vec![
+                            GradientStop {
+                                pos: 0.0,
+                                color: Color::RED,
+                            },
+                            GradientStop {
+                                pos: 0.3,
+                                color: Color::RED,
+                            },
+                            GradientStop {
+                                pos: 0.3,
+                                color: Color::YELLOW,
+                            },
+                            GradientStop {
+                                pos: 0.5,
+                                color: Color::YELLOW,
+                            },
+                            GradientStop {
+                                pos: 0.5,
+                                color: Color::BLUE,
+                            },
+                            GradientStop {
+                                pos: 0.8,
+                                color: Color::BLUE,
+                            },
+                            GradientStop {
+                                pos: 0.8,
+                                color: Color::GREEN,
+                            },
+                            GradientStop {
+                                pos: 1.0,
+                                color: Color::GREEN,
+                            },
+                        ],
+                    )))
+                    .with_corner_radius(2.0)
+                    .with_border_width(2.0)
+                    .lens(AppState::slow_progress),
             ),
     );
     flex.add_spacer(10.0);

--- a/examples/progress_bar.rs
+++ b/examples/progress_bar.rs
@@ -127,6 +127,11 @@ fn build_ui() -> impl Widget<AppState> {
             ),
     );
     flex.add_spacer(10.0);
+    flex.add_child(
+        Flex::column()
+            .with_child(Label::new("Theme Configured Progress Bar"))
+            .with_child(ProgressBar::new().lens(AppState::leaping_progress)),
+    );
 
     flex
 }

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -34,7 +34,6 @@ use tracing::instrument;
 /// A progress bar, displaying a numeric progress value.
 ///
 /// This type impls `Widget<f64>`, expecting a float in the range `0.0..1.0`.
-/// TODO: I removed the Default trait derive, but should add it back
 #[derive(Debug, Clone)]
 pub struct ProgressBar {
     bar_brush: Option<PaintBrush>,
@@ -161,8 +160,12 @@ impl Widget<f64> for ProgressBar {
         env: &Env,
     ) -> Size {
         bc.debug_check("ProgressBar");
+        // bc.constrain(Size::new(
+        //     bc.max().width,
+        //     env.get(theme::BASIC_WIDGET_HEIGHT),
+        // ))
         bc.constrain(Size::new(
-            bc.max().width,
+            env.get(theme::WIDE_WIDGET_WIDTH),
             env.get(theme::BASIC_WIDGET_HEIGHT),
         ))
     }

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -14,28 +14,34 @@
 
 //! A modified progress bar widget demo. The goal here is to put more
 //! configuration on the control, using theme colours as defaults and
-//! allowing them to be overwritten using Option<> values.
+//! allowing them to be overwritten using Option<T> and KeyOrValue<T> values.
 //!
-//! TODO:
-//! More dynamic sizing
-//! Allow the widget some internal text (just text or an arbitrary widget)
-//! Paint entire bar and truncate so the gradients don't shrink to fit it.
+//! Building on the existing progress bar in druid.
+//! Making styling options more configurable, using theme values as defaults, with options in the widget to override.
+//! Removed constraint on widget width, the widget will now expand to fit its container.
+//! Future Idea: Add optional configuration for text that would go over the progress bar.
+//! Future Idea: Draw the entire rounded rectangle for the progress bar and then truncate it, so gradients don't size to the current progress, but always to what would be a full progress bar. At least as an option.
+//! TODO: Should width and height be completely configurable, both sized to expand into their container?
+//! TODO: review theme values more generally, concerned that they might not be getting used consistently.
+//! TODO: Use druid::BackgroundBrush instead of druid::piet::PaintBrush, but it ruins all my derives.
 
 use druid::piet::PaintBrush;
 use druid::widget::prelude::*;
-use druid::{theme, Color, LinearGradient, Point, Rect, UnitPoint};
+use druid::widget::BackgroundBrush;
+use druid::{theme, Color, KeyOrValue, LinearGradient, Point, Rect, UnitPoint};
 use tracing::instrument;
 
 /// A progress bar, displaying a numeric progress value.
 ///
 /// This type impls `Widget<f64>`, expecting a float in the range `0.0..1.0`.
-#[derive(Debug, Clone, Default)]
+/// TODO: I removed the Default trait derive, but should add it back
+#[derive(Debug, Clone)]
 pub struct ProgressBar {
-    bar_brush: Option<druid::piet::PaintBrush>,
-    background_brush: Option<druid::piet::PaintBrush>,
-    corner_radius: Option<f64>,
-    border_colour: Option<druid::Color>,
-    border_width: Option<f64>,
+    bar_brush: Option<PaintBrush>,
+    background_brush: Option<PaintBrush>,
+    corner_radius: KeyOrValue<f64>,
+    border_colour: KeyOrValue<Color>,
+    border_width: KeyOrValue<f64>,
 }
 
 impl ProgressBar {
@@ -44,29 +50,29 @@ impl ProgressBar {
         Self::default()
     }
 
-    pub fn with_bar_brush(mut self, cl: druid::piet::PaintBrush) -> Self {
+    pub fn with_bar_brush(mut self, cl: PaintBrush) -> Self {
         self.bar_brush = Some(cl);
         self
     }
-    pub fn with_back_brush(mut self, cl: druid::piet::PaintBrush) -> Self {
+    pub fn with_back_brush(mut self, cl: PaintBrush) -> Self {
         self.background_brush = Some(cl);
         self
     }
     pub fn with_corner_radius(mut self, c_rad: f64) -> Self {
-        self.corner_radius = Some(c_rad);
+        self.corner_radius = KeyOrValue::Concrete(c_rad);
         self
     }
     pub fn with_border_width(mut self, c_rad: f64) -> Self {
-        self.border_width = Some(c_rad);
+        self.border_width = KeyOrValue::Concrete(c_rad);
         self
     }
-    pub fn with_border_colour(mut self, cl: druid::Color) -> Self {
-        self.border_colour = Some(cl);
+    pub fn with_border_colour(mut self, cl: Color) -> Self {
+        self.border_colour = KeyOrValue::Concrete(cl);
         self
     }
 
     //Internal getters that resolve using theme or control values.
-    fn bar_brush(&self, env: &Env) -> druid::piet::PaintBrush {
+    fn bar_brush(&self, env: &Env) -> PaintBrush {
         self.bar_brush
             .clone()
             .unwrap_or(PaintBrush::Linear(LinearGradient::new(
@@ -75,7 +81,7 @@ impl ProgressBar {
                 (env.get(theme::PRIMARY_LIGHT), env.get(theme::PRIMARY_DARK)),
             )))
     }
-    fn background_brush(&self, env: &Env) -> druid::piet::PaintBrush {
+    fn background_brush(&self, env: &Env) -> PaintBrush {
         self.background_brush
             .clone()
             .unwrap_or(PaintBrush::Linear(LinearGradient::new(
@@ -87,19 +93,17 @@ impl ProgressBar {
                 ),
             )))
     }
-    fn corner_radius(&self, env: &Env) -> f64 {
-        self.corner_radius
-            .clone()
-            .unwrap_or(env.get(theme::PROGRESS_BAR_RADIUS))
-    }
-    //TODO: This should probably be a theme setting like everything else. No good option yet.
-    fn border_width(&self, _env: &Env) -> f64 {
-        self.border_width.clone().unwrap_or(2.0)
-    }
-    fn border_colour(&self, env: &Env) -> Color {
-        self.border_colour
-            .clone()
-            .unwrap_or(env.get(theme::BORDER_DARK))
+}
+
+impl Default for ProgressBar {
+    fn default() -> Self {
+        ProgressBar {
+            bar_brush: None,
+            background_brush: None,
+            corner_radius: KeyOrValue::Key(theme::PROGRESS_BAR_RADIUS),
+            border_colour: KeyOrValue::Key(theme::BORDER_DARK),
+            border_width: KeyOrValue::Key(theme::BUTTON_BORDER_WIDTH),
+        }
     }
 }
 
@@ -148,34 +152,33 @@ impl Widget<f64> for ProgressBar {
 
     #[instrument(name = "ProgressBar", level = "trace", skip(self, ctx, data, env))]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &f64, env: &Env) {
-        let border_width = self.border_width.clone().unwrap_or(2.0);
+        let border_width = self.border_width.resolve(env);
 
         let height = env.get(theme::BASIC_WIDGET_HEIGHT);
-        let clamped = data.max(0.0).min(1.0);
         let inset = -border_width / 2.0;
         let size = ctx.size();
-        let rounded_rect = Size::new(size.width, height)
+        let full_rect = Size::new(size.width, height)
             .to_rect()
             .inset(inset)
-            .to_rounded_rect(self.corner_radius(env));
+            .to_rounded_rect(self.corner_radius.resolve(env));
 
         // Paint the border
-        ctx.stroke(rounded_rect, &self.border_colour(env), border_width);
+        ctx.stroke(full_rect, &self.border_colour.resolve(env), border_width);
 
         // Paint the background
         // This has been changed from a gradient from top to bottom because I thought this made more sense visually.
-        ctx.fill(rounded_rect, &self.background_brush(env));
+        ctx.fill(full_rect, &self.background_brush(env));
 
         // Paint the bar
-        let calculated_bar_width = clamped * rounded_rect.width();
+        let calculated_bar_width = data.max(0.0).min(1.0) * full_rect.width();
 
-        let rounded_rect = Rect::from_origin_size(
+        let bar_rect = Rect::from_origin_size(
             Point::new(-inset, 0.),
             Size::new(calculated_bar_width, height),
         )
         .inset((0.0, inset))
-        .to_rounded_rect(self.corner_radius(env));
+        .to_rounded_rect(self.corner_radius.resolve(env));
 
-        ctx.fill(rounded_rect, &self.bar_brush(env));
+        ctx.fill(bar_rect, &self.bar_brush(env));
     }
 }

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -20,14 +20,13 @@
 //! Making styling options more configurable, using theme values as defaults, with options in the widget to override.
 //! Removed constraint on widget width, the widget will now expand to fit its container.
 //! Future Idea: Add optional configuration for text that would go over the progress bar.
-//! Future Idea: Draw the entire rounded rectangle for the progress bar and then truncate it, so gradients don't size to the current progress, but always to what would be a full progress bar. At least as an option.
 //! TODO: Should width and height be completely configurable, both sized to expand into their container?
 //! TODO: review theme values more generally, concerned that they might not be getting used consistently.
 //! TODO: Use druid::BackgroundBrush instead of druid::piet::PaintBrush, but it ruins all my derives.
 
 use druid::piet::PaintBrush;
 use druid::widget::prelude::*;
-use druid::widget::BackgroundBrush;
+// use druid::widget::BackgroundBrush;
 use druid::{theme, Color, KeyOrValue, LinearGradient, Point, Rect, UnitPoint};
 use tracing::instrument;
 

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -50,6 +50,7 @@ impl ProgressBar {
         Self::default()
     }
 
+    //'with' functions returning self.
     pub fn with_bar_brush(mut self, cl: PaintBrush) -> Self {
         self.bar_brush = Some(cl);
         self
@@ -69,6 +70,22 @@ impl ProgressBar {
     pub fn with_border_colour(mut self, cl: Color) -> Self {
         self.border_colour = KeyOrValue::Concrete(cl);
         self
+    }
+    //Set functions, returning
+    pub fn set_bar_brush(mut self, cl: PaintBrush) {
+        self.bar_brush = Some(cl);
+    }
+    pub fn set_back_brush(mut self, cl: PaintBrush) {
+        self.background_brush = Some(cl);
+    }
+    pub fn set_corner_radius(mut self, c_rad: f64) {
+        self.corner_radius = KeyOrValue::Concrete(c_rad);
+    }
+    pub fn set_border_width(mut self, c_rad: f64) {
+        self.border_width = KeyOrValue::Concrete(c_rad);
+    }
+    pub fn set_border_colour(mut self, cl: Color) {
+        self.border_colour = KeyOrValue::Concrete(cl);
     }
 
     //Internal getters that resolve using theme or control values.

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -199,6 +199,17 @@ impl Widget<f64> for ProgressBar {
         .inset((0.0, inset))
         .to_rounded_rect(self.corner_radius.resolve(env));
 
-        ctx.fill(bar_rect, &self.bar_brush(env));
+        //Old method would't apply brush to the full bar.
+        // ctx.fill(bar_rect, &self.bar_brush(env));
+
+        //Renders full bar and clips.
+        ctx.render_ctx
+            .save()
+            .expect("Could not save render context in, ProgressBar Widget.");
+        ctx.render_ctx.clip(bar_rect);
+        ctx.fill(full_rect, &self.bar_brush(env));
+        ctx.render_ctx
+            .restore()
+            .expect("Could not restore render context in, ProgressBar Widget.");
     }
 }


### PR DESCRIPTION
Cleaned up default values config for ProgressBar, using KeyOrValue<T> instead of Option<T> to remove boilerplate code.

Thinking about using BackgroundBrush instead of piet::PaintBrush, but it messes up a lot of Trait derives.