### PR TITLE
Rename and clean-up separator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ mod multi_value;
 pub mod navigator;
 pub mod partial;
 mod progress_bar;
-mod seperator;
+mod separator;
 pub mod theme_loader;
 mod tree;
 
@@ -43,7 +43,7 @@ pub use dynamic_sized_box::DynamicSizedBox;
 pub use list_select::ListSelect;
 pub use multi_value::{MultiCheckbox, MultiRadio};
 pub use progress_bar::ProgressBar;
-pub use seperator::{Orientation, Seperator};
+pub use separator::{Orientation, Separator};
 pub use tree::{Tree, TreeNode, Wedge};
 
 #[cfg(feature = "async")]

--- a/src/separator.rs
+++ b/src/separator.rs
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! A Seperator widget.
+//! A separator widget.
 
 use druid::widget::prelude::*;
 use druid::{kurbo::Line, piet::StrokeStyle};
 use druid::{theme, Color, KeyOrValue};
 
-/// A seperator widget.
-pub struct Seperator {
-    size: KeyOrValue<f64>,
+/// A separator widget.
+pub struct Separator {
+    width: KeyOrValue<f64>,
     color: KeyOrValue<Color>,
     orientation: Orientation,
     stroke_style: StrokeStyle,
@@ -31,10 +31,10 @@ pub enum Orientation {
     Horizontal,
 }
 
-impl Default for Seperator {
+impl Default for Separator {
     fn default() -> Self {
-        Seperator {
-            size: theme::BUTTON_BORDER_WIDTH.into(),
+        Separator {
+            width: theme::BUTTON_BORDER_WIDTH.into(),
             color: theme::BORDER_LIGHT.into(),
             orientation: Orientation::Horizontal,
             stroke_style: StrokeStyle::new(),
@@ -42,17 +42,20 @@ impl Default for Seperator {
     }
 }
 
-impl Seperator {
+impl Separator {
     pub fn new() -> Self {
         Self::default()
     }
-    pub fn with_size(mut self, size: impl Into<KeyOrValue<f64>>) -> Self {
-        self.size = size.into();
+
+    /// Set the separator width (thickness).
+    pub fn with_width(mut self, width: impl Into<KeyOrValue<f64>>) -> Self {
+        self.width = width.into();
         self
     }
 
-    pub fn set_size(&mut self, size: impl Into<KeyOrValue<f64>>) {
-        self.size = size.into();
+    /// Set the separator width (thickness).
+    pub fn set_width(&mut self, width: impl Into<KeyOrValue<f64>>) {
+        self.width = width.into();
     }
 
     pub fn with_color(mut self, color: impl Into<KeyOrValue<Color>>) -> Self {
@@ -60,13 +63,17 @@ impl Seperator {
         self
     }
 
+    pub fn set_color(&mut self, color: impl Into<KeyOrValue<Color>>) {
+        self.color = color.into();
+    }
+
     pub fn with_stroke_style(mut self, stroke_style: StrokeStyle) -> Self {
         self.stroke_style = stroke_style;
         self
     }
 
-    pub fn set_color(&mut self, color: impl Into<KeyOrValue<Color>>) {
-        self.color = color.into();
+    pub fn set_stroke_style(&mut self, stroke_style: StrokeStyle) {
+        self.stroke_style = stroke_style;
     }
 
     pub fn with_orientation(mut self, orientation: Orientation) -> Self {
@@ -77,13 +84,9 @@ impl Seperator {
     pub fn set_orientation(&mut self, orientation: Orientation) {
         self.orientation = orientation;
     }
-
-    pub fn set_stroke_style(&mut self, stroke_style: StrokeStyle) {
-        self.stroke_style = stroke_style;
-    }
 }
 
-impl<T> Widget<T> for Seperator {
+impl<T> Widget<T> for Separator {
     fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut T, _env: &Env) {}
 
     fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &T, _env: &Env) {}
@@ -91,19 +94,18 @@ impl<T> Widget<T> for Seperator {
     fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: &T, _data: &T, _env: &Env) {}
 
     fn layout(&mut self, _ctx: &mut LayoutCtx, bc: &BoxConstraints, _data: &T, env: &Env) -> Size {
-        let size = self.size.resolve(env);
+        let width = self.width.resolve(env);
         let size = match self.orientation {
-            Orientation::Vertical => (size, f64::INFINITY),
-            Orientation::Horizontal => (f64::INFINITY, size),
+            Orientation::Vertical => (width, f64::INFINITY),
+            Orientation::Horizontal => (f64::INFINITY, width),
         };
         bc.constrain(size)
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, _data: &T, env: &Env) {
         let line = Line::new((0., 0.), ctx.size().to_vec2().to_point());
-
         let color = self.color.resolve(env);
-        let size = self.size.resolve(env);
-        ctx.stroke_styled(line, &color, size, &self.stroke_style);
+        let width = self.width.resolve(env);
+        ctx.stroke_styled(line, &color, width, &self.stroke_style);
     }
 }


### PR DESCRIPTION
- Fix name by renaming from `seperator` to `separator`
- Group builder/non-builder methods together
- Rename `size` -> `width` for the line thickness, conforming to the
  usual terminology for this