### PR TITLE
example/dropdown: submit DROP as a command instead of a notification

### DIFF
--- a/examples/dropdown.rs
+++ b/examples/dropdown.rs
@@ -32,7 +32,7 @@ fn main_widget() -> impl Widget<DropDownState> {
                         .with_flex_spacer(1.)
                         .with_child(
                             Button::new("V")
-                                .on_click(|ctx: &mut EventCtx, _, _| ctx.submit_notification(DROP)),
+                                .on_click(|ctx: &mut EventCtx, _, _| ctx.submit_command(DROP)),
                         ),
                     |_, _| {
                         let places: Vec<(&'static str, String)> =
@@ -53,7 +53,7 @@ fn main_widget() -> impl Widget<DropDownState> {
                         .with_flex_spacer(1.)
                         .with_child(
                             Button::new("V")
-                                .on_click(|ctx: &mut EventCtx, _, _| ctx.submit_notification(DROP)),
+                                .on_click(|ctx: &mut EventCtx, _, _| ctx.submit_command(DROP)),
                         ),
                     |_, _| {
                         RadioGroup::new(vec![
@@ -70,7 +70,7 @@ fn main_widget() -> impl Widget<DropDownState> {
             .with_child(
                 Dropdown::new_sized(
                     Button::new(|f: &Fruit, _: &Env| format!("{:?}", f))
-                        .on_click(|ctx: &mut EventCtx, _, _| ctx.submit_notification(DROP)),
+                        .on_click(|ctx: &mut EventCtx, _, _| ctx.submit_command(DROP)),
                     |_, _| {
                         RadioGroup::new(vec![
                             ("Apple", Fruit::Apple),


### PR DESCRIPTION
Follow-up to
https://github.com/linebender/druid-widget-nursery/pull/37

https://github.com/linebender/druid-widget-nursery/issues/31

---
Build will fail if not rebased on top of https://github.com/linebender/druid-widget-nursery/pull/42