### PR TITLE
select: collapse if open when clicked

### DIFF
--- a/src/dropdown_select.rs
+++ b/src/dropdown_select.rs
@@ -68,8 +68,13 @@ impl<T: Data + PartialEq> DropdownSelect<T> {
                 .unwrap()
         })
         .on_click(|ctx: &mut EventCtx, t: &mut DropdownState<T>, _| {
-            t.expanded = true;
-            ctx.submit_command(DROP)
+            if t.expanded {
+                t.expanded = false;
+                ctx.submit_command(COLLAPSE.to(ctx.widget_id()));
+            } else {
+                t.expanded = true;
+                ctx.submit_command(DROP.to(ctx.widget_id()))
+            }
         });
 
         let make_drop = move |_t: &DropdownState<T>, env: &Env| {


### PR DESCRIPTION
Currently when clicking on the `dropdown_select` header a second time, it opens a new window.
It is expected that it collapses instead.

Collapse if open.

---
Build will fail if not rebased on top of https://github.com/linebender/druid-widget-nursery/pull/42