### PR TITLE
ci/clippy: scan all targets and features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,4 +50,4 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: -p druid-widget-nursery -- -D warnings
+        args: -p druid-widget-nursery --all-targets --all-features -- -D warnings


### PR DESCRIPTION
Currently, the hot_reload and future widgets are not scanned.
Ensure that CI scans code behind feature and target flags.