### PR TITLE
cargo/tokio: include time feature used by async example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [features]
-async = ["tokio", "futures", "flume"]
+async = ["tokio/rt", "futures", "flume"]
 hot-reload = ["libloading", "notify5", "rand"]
 
 [dependencies.druid]
@@ -22,7 +22,7 @@ log = "0.4.11"
 notify = { version = "4.0.12", optional = true }
 
 # async
-tokio = { version = "1.0", features = ["rt"], optional = true }
+tokio = { version = "1.0", features = ["rt", "time"], optional = true }
 futures = { version = "0.3", optional = true }
 flume = { version = "0.10", optional = true }
 


### PR DESCRIPTION
The async example uses a feature that is not declared, which causes
rust-analyzer to display an error.