### PR TITLE
delay list selection until MouseUp

### DIFF
--- a/src/list_select.rs
+++ b/src/list_select.rs
@@ -128,8 +128,10 @@ impl<T: Data + PartialEq> Controller<T, Flex<T>> for ListSelectController<T> {
         let mut selected = false;
 
         if let Event::MouseDown(_) = event {
-            selected = true;
             ctx.request_focus();
+        }
+        if let Event::MouseUp(_) = event {
+            selected = ctx.is_hot() && ctx.has_focus();
         }
         if let Event::KeyDown(key_event) = event {
             match key_event.key {


### PR DESCRIPTION
This allows the selected ListItem to update before calling the on_select callback.

This is a partial solution to #57.  It works ok for regular clicks, however, if the user presses the mouse down in another section of the gui, drags over the list (that already has focus), and then releases the mouse a selection event is still triggered.  I'm not familiar enough with Druid to have a good idea on how to resolve that type of interaction.