### PR TITLE
Add section on dependencies, with note on overriding druid version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ We don't insist that all widgets always build when updating to a newer version o
 
 So, in summary, the default assumption for PRs to this repo will be to merge, but this policy includes future PRs that might change or reverse stuff in previous PRs. For more information I recommend reading [the optimistic merging article linked here and above][optimistic merging], which offers an interesting approach to managing open source projects irrespective of its use here.
 
+## Using this library
+
+Add the following to your `Cargo.toml`. You will need to get the current druid `rev` from this repository's [Cargo.toml](Cargo.toml).
+```toml
+druid-widget-nursery = { git = "https://github.com/linebender/druid-widget-nursery" }
+
+[patch.crates-io.druid]
+git = "https://github.com/linebender/druid"
+rev = "<copy the current druid rev from this repository's Cargo.toml>"
+```
+The `rev` in your `Cargo.toml` should match the `rev` in this repository's `[dependencies.druid]`, so that your app depends on the same version of druid as this library. Otherwise you may end up with problems with [multiple versions of `druid` installed](https://github.com/linebender/druid-widget-nursery/issues/20). The snippet above uses Cargo's [patch functionality](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html), which is designed for overriding dependencies like this.
+
+Once you have `druid-widget-nursery` installed, you can `use druid_widget_nursery` to import the various widgets. For many examples on using various widgets, check out the [examples] directory.
+
 # Widgets
 
 If you add a new widget, please add its name and a short summary here.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ druid-widget-nursery = { git = "https://github.com/linebender/druid-widget-nurse
 git = "https://github.com/linebender/druid"
 rev = "<copy the current druid rev from this repository's Cargo.toml>"
 ```
-The `rev` in your `Cargo.toml` should match the `rev` in this repository's `[dependencies.druid]`, so that your app depends on the same version of druid as this library. Otherwise you may end up with problems with [multiple versions of `druid` installed](https://github.com/linebender/druid-widget-nursery/issues/20). The snippet above uses Cargo's [patch functionality](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html), which is designed for overriding dependencies like this.
+The `rev` in your `Cargo.toml` should match the `rev` under `[dependencies.druid]` in this repo's `Cargo.toml`. This ensures that your app depends on the same version of druid as this library - otherwise you may end up with problems with [multiple versions of `druid` installed](https://github.com/linebender/druid-widget-nursery/issues/20). For more on the override syntax above, see [Cargo's `patch` documentation](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html).
 
-Once you have `druid-widget-nursery` installed, you can `use druid_widget_nursery` to import the various widgets. For many examples on using various widgets, check out the [examples] directory.
+Once you have `druid-widget-nursery` installed, you can import the various widgets as usual with `use druid_widget_nursery::YourWidgetNameHere`. For specific examples of using the various widgets, check out the [examples](examples/) directory.
 
 # Widgets
 


### PR DESCRIPTION
This resolves the documentation issue that led to #20, and should help folks get started. I considered adding a disclaimer about it being an unstable development library, but the first paragraph communicates that, I think.
 
I used `[patch]` as suggested by @Maan2003 [on Zulip](https://xi.zulipchat.com/#narrow/stream/255910-druid-help/topic/.E2.9C.94.20DropdownSelect.20example.20broken.3F) - I knew nothing about `[patch]` before today, so please correct and edit as need be, but this seemed to do the trick!