### PR TITLE
FutureWidget: make it work on target wasm32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ tracing = { version = "0.1.22" }
 
 [[example]]
 name = "async"
-required-features = ["async", "tokio/time"]
+required-features = ["async", "tokio/rt-multi-thread", "tokio/macros", "tokio/time"]
 
 [[example]]
 name = "animator"

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -16,12 +16,13 @@ use std::time::Duration;
 
 use druid::widget::{Flex, Label, Spinner};
 use druid::{AppLauncher, Widget, WidgetExt, WindowDesc};
-use druid_widget_nursery::{AsyncDelegate, FutureWidget};
+use druid_widget_nursery::FutureWidget;
 use tokio::time;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let window = WindowDesc::new(build_root_widget());
-    AsyncDelegate::new(AppLauncher::with_window(window))
+    AppLauncher::with_window(window)
         .log_to_console()
         .launch(())
         .unwrap();

--- a/src/future_widget.rs
+++ b/src/future_widget.rs
@@ -16,90 +16,27 @@
 
 // TODO: add StreamWidget
 
-use std::{any::Any, future::Future, pin::Pin, thread};
+use std::{any::Any, future::Future, pin::Pin};
 
 use druid::widget::prelude::*;
 use druid::{
-    AppDelegate, AppLauncher, Data, ExtEventSink, Handled, Selector, SingleUse, Target, WidgetPod,
+    Data, Selector, SingleUse, Target, WidgetPod,
 };
-use flume::{Receiver, Sender};
-use futures::future::{self, BoxFuture};
-use futures::prelude::*;
-use tokio::runtime;
-
-struct Request {
-    future: Pin<Box<dyn Future<Output = Box<dyn Any + Send>> + Send>>,
-    sender: WidgetId,
-}
 
 struct Response {
     value: Box<dyn Any + Send>,
 }
 
 const ASYNC_RESPONSE: Selector<SingleUse<Response>> = Selector::new("druid-async.async-response");
-const SPAWN_ASYNC: Selector<SingleUse<Request>> = Selector::new("druid-async.spawn-async");
 
-pub struct Delegate {
-    tx: Sender<Request>,
-}
-
-impl Delegate {
-    pub fn new<T: Data + 'static>(launcher: AppLauncher<T>) -> AppLauncher<T> {
-        let sink = launcher.get_external_handle();
-        let (tx, rx) = flume::unbounded();
-        thread::spawn(move || {
-            other_thread(sink, rx);
-        });
-
-        launcher.delegate(Self { tx })
-    }
-}
-
-impl<T: Data> AppDelegate<T> for Delegate {
-    fn command(
-        &mut self,
-        _ctx: &mut druid::DelegateCtx,
-        _target: druid::Target,
-        cmd: &druid::Command,
-        _data: &mut T,
-        _env: &Env,
-    ) -> Handled {
-        if let Some(req) = cmd.get(SPAWN_ASYNC) {
-            let req = req.take().expect("Someone stole our SPAWN_ASYNC command.");
-            self.tx.send(req).unwrap();
-            Handled::Yes
-        } else {
-            Handled::No
-        }
-    }
-}
-
-// TODO: make this work with other runtimes
-fn other_thread(sink: ExtEventSink, rx: Receiver<Request>) {
-    let rt = runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap();
-    rt.block_on(async {
-        let rx = rx.stream();
-        rx.for_each(|req| {
-            let sink = sink.clone();
-            rt.spawn(async move {
-                let res = req.future.await;
-                let res = Response { value: res };
-                let sender = req.sender;
-
-                sink.submit_command(ASYNC_RESPONSE, SingleUse::new(res), Target::Widget(sender))
-                    .unwrap();
-            });
-            future::ready(())
-        })
-        .await;
-    });
-}
-
+#[cfg(target_arch="wasm32")]
 pub type FutureWidgetAction<T> =
-    Box<dyn FnOnce(&T, &Env) -> BoxFuture<'static, Box<dyn Any + Send>>>;
+    Box<dyn FnOnce(&T, &Env) -> Pin<Box<dyn Future<Output = Box<dyn Any + Send>>>>>;
+
+#[cfg(not(target_arch="wasm32"))]
+pub type FutureWidgetAction<T> =
+    Box<dyn FnOnce(&T, &Env) -> Pin<Box<dyn Send + Future<Output = Box<dyn Any + Send>>>>>;
+
 pub type FutureWidgetDone<T, U> = Box<dyn FnOnce(Box<U>, &mut T, &Env) -> Box<dyn Widget<T>>>;
 
 pub struct FutureWidget<T, U> {
@@ -108,6 +45,31 @@ pub struct FutureWidget<T, U> {
     on_done: Option<FutureWidgetDone<T, U>>,
 }
 
+#[cfg(target_arch="wasm32")]
+impl<T, U> FutureWidget<T, U> {
+    pub fn new<FMaker, Fut, Done>(
+        future_maker: FMaker,
+        pending: impl Widget<T> + 'static,
+        on_done: Done,
+    ) -> Self
+    where
+        U: Send + 'static,
+        FMaker: FnOnce(&T, &Env) -> Fut + 'static,
+        Fut: Future<Output = U> + 'static,
+        Done: FnOnce(Box<U>, &mut T, &Env) -> Box<dyn Widget<T>> + 'static,
+    {
+        Self {
+            future: Some(Box::new(move |data, env| {
+                let fut = future_maker(data, env);
+                Box::pin(async move { Box::new(fut.await) as _ })
+            })),
+            inner: WidgetPod::new(Box::new(pending)),
+            on_done: Some(Box::new(on_done)),
+        }
+    }
+}
+
+#[cfg(not(target_arch="wasm32"))]
 impl<T, U> FutureWidget<T, U> {
     pub fn new<FMaker, Fut, Done>(
         future_maker: FMaker,
@@ -142,22 +104,32 @@ impl<T: Data, U: 'static> Widget<T> for FutureWidget<T, U> {
                 ctx.children_changed();
                 return;
             }
-            #[cfg(debug_assertions)]
-            if cmd.is(SPAWN_ASYNC) {
-                // SPAWN_ASYNC should always be handled by the delegate
-                panic!("FutureWidget used without using druid_async::Delegate");
-            }
         }
         self.inner.event(ctx, event, data, env);
     }
 
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+
         if let LifeCycle::WidgetAdded = event {
-            ctx.submit_command(SPAWN_ASYNC.with(SingleUse::new(Request {
-                future: (self.future.take().unwrap())(data, env),
-                sender: ctx.widget_id(),
-            })));
+            let sink = ctx.get_external_handle();
+            let widget_id = ctx.widget_id();
+            let future = self.future.take().unwrap()(data, env);
+            let task = async move {
+                let data = future.await;
+                sink.submit_command(
+                    ASYNC_RESPONSE,
+                    SingleUse::new(Response { value: data }),
+                    Target::Widget(widget_id),
+                ).unwrap();
+            };
+
+            #[cfg(target_arch="wasm32")]
+            wasm_bindgen_futures::spawn_local(task);
+
+            #[cfg(not(target_arch="wasm32"))]
+            tokio::spawn(task);
         }
+
         self.inner.lifecycle(ctx, event, data, env)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,4 +80,4 @@ pub use widget_ext::WidgetExt;
 pub use advanced_slider::AdvancedSlider;
 
 #[cfg(feature = "async")]
-pub use future_widget::{Delegate as AsyncDelegate, FutureWidget};
+pub use future_widget::FutureWidget;


### PR DESCRIPTION
JsFutures are not "Send", so it is not possible to send the future
to a worker task.

This patch spawns the future inside lifecycle() instead of sending
it to the AsyncDelegate. This also makes AsyncDelegate obsolete.

Signed-off-by: Dietmar Maurer <dietmar@proxmox.com>