### PR TITLE
Add FlexTable widget

### DIFF
--- a/examples/flex-table.rs
+++ b/examples/flex-table.rs
@@ -1,0 +1,193 @@
+// Copyright 2021 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Dietmar Maurer <dietmar@proxmox.com>
+
+use druid::widget::{
+    Align, Container, CrossAxisAlignment, Flex, Label, Stepper, TextBox, WidgetExt,
+};
+use druid::{theme, AppLauncher, Color, Data, Env, Lens, UnitPoint, Widget, WindowDesc};
+
+use druid_widget_nursery::table::{
+    FlexTable, TableCellVerticalAlignment, TableColumnWidth, TableRow,
+};
+
+#[derive(Clone, Data, Default, Lens)]
+struct DemoState {
+    pub input_username: String,
+    pub input_password: String,
+    age: f64,
+}
+
+fn make_imput_form_example() -> impl Widget<DemoState> {
+    use TableColumnWidth::*;
+
+    FlexTable::new()
+        .inner_border(theme::BORDER_LIGHT, 1.)
+        .with_column_width(Intrinsic)
+        .with_column_width((Flex(1.), 100.))
+        .with_row(
+            TableRow::new()
+                .with_child(Label::new("Username:").align_horizontal(UnitPoint::RIGHT))
+                .with_child(
+                    TextBox::new()
+                        .with_placeholder("Username")
+                        .expand_width()
+                        .lens(DemoState::input_username),
+                ),
+        )
+        .with_row(
+            TableRow::new()
+                .with_child(Label::new("Password:").align_horizontal(UnitPoint::RIGHT))
+                .with_child(
+                    TextBox::new()
+                        .with_placeholder("Password")
+                        .expand_width()
+                        .lens(DemoState::input_password),
+                ),
+        )
+        .border(Color::WHITE, 1.)
+}
+
+fn make_row_alignment_example() -> impl Widget<DemoState> {
+    let mut table = FlexTable::new()
+        .inner_border(theme::BORDER_LIGHT, 1.)
+        .default_column_width(TableColumnWidth::Intrinsic);
+
+    use TableCellVerticalAlignment::*;
+
+    let mut row = TableRow::new().vertical_alignment(Baseline);
+
+    row.add_child(Label::new("Baseline"));
+
+    row.add_child(Label::new("Your name is:"));
+
+    row.add_child(
+        TextBox::new()
+            .with_placeholder("Username")
+            .expand_width()
+            .lens(DemoState::input_username),
+    );
+
+    row.add_child(Label::new("Your age is:").lens(DemoState::age));
+    row.add_child(Label::new(|v: &f64, _: &Env| v.to_string()).lens(DemoState::age));
+    row.add_child(
+        Stepper::new()
+            .with_range(0.0, 120.0)
+            .with_step(1.0)
+            .with_wraparound(true)
+            .lens(DemoState::age),
+    );
+
+    table.add_row(row);
+
+    for align in [Bottom, Middle, Top, Fill] {
+        let mut row = TableRow::new().min_height(40.).vertical_alignment(align);
+
+        row.add_child(
+            Label::new(format!("{:?}", align))
+                .with_text_color(Color::BLACK)
+                .background(theme::BORDER_LIGHT)
+                .border(Color::WHITE, 1.)
+                .center()
+                .expand_width()
+                .background(Color::rgb(0.4, 0.4, 0.4)),
+        );
+
+        for row_num in 1..6 {
+            row.add_child(
+                Label::new(format!("{}", row_num))
+                    .with_text_color(Color::BLACK)
+                    .background(theme::BORDER_LIGHT)
+                    .border(Color::WHITE, 1.)
+                    .center()
+                    .expand_width()
+                    .background(Color::rgb(0.4, 0.4, 0.4)),
+            );
+        }
+
+        table.add_row(row);
+    }
+
+    table.border(Color::WHITE, 1.)
+}
+
+fn make_cell_alignment_example() -> impl Widget<DemoState> {
+    let alignments = [
+        UnitPoint::TOP_LEFT,
+        UnitPoint::TOP,
+        UnitPoint::TOP_RIGHT,
+        UnitPoint::RIGHT,
+        UnitPoint::BOTTOM_RIGHT,
+        UnitPoint::BOTTOM,
+        UnitPoint::BOTTOM_LEFT,
+        UnitPoint::LEFT,
+        UnitPoint::CENTER,
+    ];
+
+    let mut row = TableRow::new().min_height(40.);
+
+    for (i, alignment) in alignments.iter().enumerate() {
+        row.add_child(
+            Align::new(*alignment, {
+                let label = Label::new(format!("{}", i))
+                    .with_text_color(Color::BLACK)
+                    .center();
+                Container::new(label)
+                    .background(theme::BORDER_LIGHT)
+                    .border(Color::WHITE, 1.)
+                    .fix_width(20.)
+                    .fix_height(20.)
+            })
+            .expand(),
+        );
+    }
+
+    FlexTable::new()
+        .inner_border(theme::BORDER_LIGHT, 1.)
+        .with_row(row)
+        .border(Color::WHITE, 1.)
+        .fix_height(42.)
+}
+
+fn make_ui() -> impl Widget<DemoState> {
+    Flex::column()
+        .cross_axis_alignment(CrossAxisAlignment::Fill)
+        .must_fill_main_axis(true)
+        .with_child(Label::new("A simple input form."))
+        .with_child(make_imput_form_example())
+        .with_default_spacer()
+        .with_child(Label::new("Row alignment example."))
+        .with_child(make_row_alignment_example())
+        .with_default_spacer()
+        .with_child(Label::new("Cell alignment example."))
+        .with_child(make_cell_alignment_example())
+        .with_default_spacer()
+        .padding(10.0)
+        .fix_height(500.)
+}
+
+pub fn main() {
+    let main_window = WindowDesc::new(make_ui())
+        .window_size((500., 500.))
+        .with_min_size((50., 50.))
+        .title("Flex Table Example");
+
+    let demo_state = DemoState::default();
+
+    AppLauncher::with_window(main_window)
+        .log_to_console()
+        .launch(demo_state)
+        .expect("Failed to launch application");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub mod prism;
 mod progress_bar;
 mod separator;
 pub mod splits;
+pub mod table;
 pub mod theme_loader;
 mod titlebar;
 mod tooltip;

--- a/src/table/flex_table.rs
+++ b/src/table/flex_table.rs
@@ -1,0 +1,569 @@
+// Copyright 2021 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Dietmar Maurer <dietmar@proxmox.com>
+
+use druid::widget::BackgroundBrush;
+use druid::{
+    BoxConstraints, Color, Data, Env, Event, EventCtx, KeyOrValue, LayoutCtx, LifeCycle,
+    LifeCycleCtx, PaintCtx, Point, RenderContext, Size, UpdateCtx, Widget,
+};
+
+use super::{ComplexTableColumnWidth, TableCellVerticalAlignment, TableColumnWidth, TableRow};
+
+#[derive(Debug)]
+struct TableBorderStyle {
+    width: KeyOrValue<f64>,
+    color: KeyOrValue<Color>,
+}
+
+/// A container with a flexible table layout.
+///
+/// Uses the flex layout algorithm (like [druid::widget::Flex]) to layout
+/// cells in each row.
+///
+/// # Examples
+/// ```
+/// # use druid::widget::Label;
+/// # use druid::Widget;
+/// # use druid_widget_nursery::table::{TableRow, FlexTable};
+/// # fn test() -> impl Widget<()> {
+/// FlexTable::new()
+///     .inner_border(druid::theme::BORDER_LIGHT, 1.)
+///     .with_row(
+///         TableRow::new()
+///             .with_child(Label::new("Row 1 / Column 1"))
+///             .with_child(Label::new("Row 2 / Column 2"))
+///     )
+///     .with_row(
+///         TableRow::new()
+///             .with_child(Label::new("Row 1 / Column 1"))
+///             .with_child(Label::new("Row 2 / Column 2"))
+///      )
+/// # }
+/// ```
+pub struct FlexTable<T> {
+    default_column_width: ComplexTableColumnWidth,
+    default_vertical_alignment: TableCellVerticalAlignment,
+    column_widths: Vec<ComplexTableColumnWidth>,
+    children: Vec<TableRow<T>>,
+    row_border: Option<TableBorderStyle>,
+    col_border: Option<TableBorderStyle>,
+    background: Option<BackgroundBrush<T>>,
+    row_starts: Option<Vec<f64>>,
+    col_starts: Option<Vec<f64>>,
+}
+
+impl<T: Data> FlexTable<T> {
+    /// Create a new empty table.
+    pub fn new() -> Self {
+        Self {
+            default_column_width: TableColumnWidth::Flex(1.0).into(),
+            default_vertical_alignment: TableCellVerticalAlignment::Middle,
+            column_widths: Vec::new(),
+            children: Vec::new(),
+            row_border: None,
+            col_border: None,
+            row_starts: None,
+            col_starts: None,
+            background: None,
+        }
+    }
+
+    /// Builder-style method to set the table background brush
+    pub fn background(mut self, brush: impl Into<BackgroundBrush<T>>) -> Self {
+        self.set_background(brush);
+        self
+    }
+
+    /// Set the table background brush
+    pub fn set_background(&mut self, brush: impl Into<BackgroundBrush<T>>) {
+        self.background = Some(brush.into());
+    }
+
+    /// Builder-style method to set the table inner border
+    pub fn inner_border(
+        mut self,
+        color: impl Into<KeyOrValue<Color>>,
+        width: impl Into<KeyOrValue<f64>>,
+    ) -> Self {
+        self.set_inner_border(color, width);
+        self
+    }
+
+    /// Set the table inner border.
+    pub fn set_inner_border(
+        &mut self,
+        color: impl Into<KeyOrValue<Color>>,
+        width: impl Into<KeyOrValue<f64>>,
+    ) {
+        let color = color.into();
+        let width = width.into();
+        self.set_row_border(color.clone(), width.clone());
+        self.set_column_border(color.clone(), width.clone());
+    }
+
+    /// Builder-style method to set the table row border.
+    pub fn row_border(
+        mut self,
+        color: impl Into<KeyOrValue<Color>>,
+        width: impl Into<KeyOrValue<f64>>,
+    ) -> Self {
+        self.set_row_border(color, width);
+        self
+    }
+
+    /// Set the table row border.
+    pub fn set_row_border(
+        &mut self,
+        color: impl Into<KeyOrValue<Color>>,
+        width: impl Into<KeyOrValue<f64>>,
+    ) {
+        self.row_border = Some(TableBorderStyle {
+            width: width.into(),
+            color: color.into(),
+        });
+    }
+
+    /// Builder-style method to set the table column border.
+    pub fn column_border(
+        mut self,
+        color: impl Into<KeyOrValue<Color>>,
+        width: impl Into<KeyOrValue<f64>>,
+    ) -> Self {
+        self.set_column_border(color, width);
+        self
+    }
+
+    /// Set the table column border.
+    pub fn set_column_border(
+        &mut self,
+        color: impl Into<KeyOrValue<Color>>,
+        width: impl Into<KeyOrValue<f64>>,
+    ) {
+        self.col_border = Some(TableBorderStyle {
+            width: width.into(),
+            color: color.into(),
+        });
+    }
+
+    /// Builder-style method to add a table column width.
+    ///
+    /// Examples:
+    /// ```
+    /// use druid_widget_nursery::table::{FlexTable, TableColumnWidth::*};
+    /// # fn test () -> FlexTable<()> {
+    ///
+    /// FlexTable::new()
+    ///    .with_column_width(64.0)                     // column 1: fixed width
+    ///    .with_column_width(Intrinsic)                // column 2: intrinsic width
+    ///    .with_column_width((Flex(1.0), 60.0))        // column 3: flex with minimum size
+    ///    .with_column_width((Flex(1.0), 60.0..200.0)) // column 4: flex with minimum and maximum
+    ///
+    ///    // column 5: flex with intrinsic size as minimum and fixed size maximum
+    ///    .with_column_width((Flex(1.0), Intrinsic, 200.0))
+    /// # }
+    /// ```
+    pub fn with_column_width<W: Into<ComplexTableColumnWidth>>(mut self, column_width: W) -> Self {
+        self.column_widths.push(column_width.into());
+        self
+    }
+
+    /// Builder-style method to set the table column width.
+    ///
+    /// If not set, the [`Self::default_column_width`] is used.
+    pub fn column_widths(mut self, column_widths: &[ComplexTableColumnWidth]) -> Self {
+        self.set_column_widths(column_widths);
+        self
+    }
+
+    /// Set the table column widths.
+    ///
+    /// If not set, the [`Self::default_column_width`] is used.
+    pub fn set_column_widths(&mut self, column_widths: &[ComplexTableColumnWidth]) {
+        self.column_widths = column_widths.to_vec();
+    }
+
+    /// Builder-style method to set the default column width.
+    pub fn default_column_width<W: Into<ComplexTableColumnWidth>>(
+        mut self,
+        default_column_width: W,
+    ) -> Self {
+        self.set_default_column_width(default_column_width);
+        self
+    }
+
+    /// Set the default column width.
+    pub fn set_default_column_width<W: Into<ComplexTableColumnWidth>>(
+        &mut self,
+        default_column_width: W,
+    ) {
+        self.default_column_width = default_column_width.into();
+    }
+
+    /// Builder-style method to set the default vertical cell alignment.
+    pub fn default_vertical_alignment(
+        mut self,
+        default_vertical_alignment: TableCellVerticalAlignment,
+    ) -> Self {
+        self.set_default_vertical_alignment(default_vertical_alignment);
+        self
+    }
+
+    /// Set the default vertical cell alignment.
+    pub fn set_default_vertical_alignment(
+        &mut self,
+        default_vertical_alignment: TableCellVerticalAlignment,
+    ) {
+        self.default_vertical_alignment = default_vertical_alignment;
+    }
+
+    /// Returns the column count
+    pub fn column_count(&self) -> usize {
+        if self.children.is_empty() {
+            0
+        } else {
+            self.children[0].children.len()
+        }
+    }
+
+    /// Builder-style method to add a table row.
+    ///
+    /// All row must have equal number of cells. Panics if not!
+    pub fn with_row(mut self, row: TableRow<T>) -> Self {
+        self.add_row(row);
+        self
+    }
+
+    /// Add a table row.
+    ///
+    /// All row must have equal number of cells. Panics if not!
+    pub fn add_row(&mut self, row: TableRow<T>) {
+        if !self.children.is_empty() {
+            if row.children.len() != self.column_count() {
+                panic!("Table::add_row - wrong row length");
+            }
+        }
+        self.children.push(row);
+    }
+}
+
+impl<T: Data> Widget<T> for FlexTable<T> {
+    fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
+        for row in self.children.iter_mut() {
+            for cell in row.children.iter_mut() {
+                cell.event(ctx, event, data, env);
+            }
+        }
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        for row in self.children.iter_mut() {
+            for cell in row.children.iter_mut() {
+                cell.lifecycle(ctx, event, data, env);
+            }
+        }
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
+        if let Some(brush) = self.background.as_mut() {
+            brush.update(ctx, old_data, data, env);
+        }
+
+        if let Some(border) = &self.row_border {
+            if ctx.env_key_changed(&border.width) {
+                ctx.request_layout();
+            }
+            if ctx.env_key_changed(&border.color) {
+                ctx.request_paint();
+            }
+        }
+
+        if let Some(border) = &self.col_border {
+            if ctx.env_key_changed(&border.width) {
+                ctx.request_layout();
+            }
+            if ctx.env_key_changed(&border.color) {
+                ctx.request_paint();
+            }
+        }
+
+        for row in self.children.iter_mut() {
+            for cell in row.children.iter_mut() {
+                cell.update(ctx, data, env);
+            }
+        }
+    }
+
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
+        let column_count = self.column_count();
+        if column_count == 0 {
+            return Size::ZERO;
+        }
+
+        if self.column_widths.len() < column_count {
+            // make sure we have all elements so that we can directly
+            // access column_widths[col_num]
+            self.column_widths
+                .resize(column_count, self.default_column_width);
+        }
+
+        let mut column_widths = self.column_widths.clone();
+
+        let mut intrinsic_widths = vec![0f64; column_count];
+        let mut row_starts = vec![0f64; self.children.len()];
+
+        let col_border_width = self
+            .col_border
+            .as_ref()
+            .map(|b| b.width.resolve(env))
+            .unwrap_or(0f64);
+        let col_border_width_sum = col_border_width * (column_count - 1) as f64;
+        let max_table_width = bc.max().width - col_border_width_sum;
+
+        let rows = self.children.len();
+        let row_border_width = self
+            .row_border
+            .as_ref()
+            .map(|b| b.width.resolve(env))
+            .unwrap_or(0f64);
+        let row_border_width_sum = row_border_width * (rows - 1) as f64;
+        let max_table_height = bc.max().height - row_border_width_sum;
+
+        use TableColumnWidth::*;
+
+        // pass 1: compute intrinsic sizes if needed
+        for col_num in 0..column_count {
+            let cw = column_widths[col_num];
+            if cw.need_intrinsic_width() {
+                let mut row_width = 0f64;
+                let mut found_size = false;
+                for row in self.children.iter_mut() {
+                    if let Some(cell) = row.children.get_mut(col_num) {
+                        let child_bc = BoxConstraints::new(
+                            Size::new(0., 0.),
+                            Size::new(std::f64::INFINITY, std::f64::INFINITY),
+                        );
+                        let size = cell.layout(ctx, &child_bc, data, env);
+                        if size.width.is_finite() {
+                            row_width = row_width.max(size.width);
+                            found_size = true;
+                        }
+                    }
+                }
+                if found_size {
+                    intrinsic_widths[col_num] = row_width;
+                } else {
+                    let flex = 1.0;
+                    column_widths[col_num] = match column_widths[col_num] {
+                        ComplexTableColumnWidth::Simple(_) => Flex(flex).into(),
+                        ComplexTableColumnWidth::Limited(_, min, max) => {
+                            ComplexTableColumnWidth::Limited(Flex(flex), min, max)
+                        }
+                    };
+                }
+            }
+        }
+
+        let col_widths = ComplexTableColumnWidth::compute_column_widths(
+            &mut column_widths,
+            &intrinsic_widths,
+            max_table_width,
+        );
+
+        let table_width = col_widths.iter().sum::<f64>() + col_border_width_sum;
+        let mut table_height = 0f64;
+
+        for (row_num, row) in self.children.iter_mut().enumerate() {
+            let mut row_height = 0f64;
+            let mut found_height = false;
+            let mut max_above_baseline = 0f64;
+            let mut max_below_baseline = 0f64;
+
+            let mut fix_columns = Vec::new();
+
+            if row_num > 0 {
+                table_height += row_border_width;
+            }
+
+            for (col_num, cell) in row.children.iter_mut().enumerate() {
+                let child_bc = BoxConstraints::new(
+                    Size::new(0., 0.),
+                    Size::new(col_widths[col_num], std::f64::INFINITY),
+                );
+                let size = cell.layout(ctx, &child_bc, data, env);
+
+                if size.height.is_finite() {
+                    found_height = true;
+                    row_height = row_height.max(size.height);
+                    let baseline_offset = cell.baseline_offset();
+                    let above_baseline = size.height - baseline_offset;
+
+                    max_above_baseline = max_above_baseline.max(above_baseline);
+                    max_below_baseline = max_below_baseline.max(baseline_offset);
+                } else {
+                    fix_columns.push(col_num);
+                }
+            }
+
+            if !found_height {
+                // all children have INF height
+                row_height = max_table_height;
+            }
+
+            for col_num in fix_columns {
+                if let Some(cell) = row.children.get_mut(col_num) {
+                    let child_bc = BoxConstraints::new(
+                        Size::new(0., 0.),
+                        Size::new(col_widths[col_num], row_height),
+                    );
+                    let size = cell.layout(ctx, &child_bc, data, env);
+
+                    let baseline_offset = cell.baseline_offset();
+                    let above_baseline = size.height - baseline_offset;
+
+                    max_above_baseline = max_above_baseline.max(above_baseline);
+                    max_below_baseline = max_below_baseline.max(baseline_offset);
+                }
+            }
+
+            let real_height = row
+                .min_height
+                .unwrap_or(0f64)
+                .max(max_above_baseline + max_below_baseline);
+
+            let mut row_width = 0f64;
+            for (col_num, cell) in row.children.iter_mut().enumerate() {
+                if col_num > 0 {
+                    row_width += col_border_width;
+                }
+                let size = cell.layout_rect().size();
+
+                let vertical_alignment = row
+                    .vertical_alignment
+                    .unwrap_or(self.default_vertical_alignment);
+
+                let dh = match vertical_alignment {
+                    TableCellVerticalAlignment::Baseline => {
+                        let baseline_offset = cell.baseline_offset();
+
+                        let above_baseline = size.height - baseline_offset;
+
+                        max_above_baseline - above_baseline
+                    }
+                    TableCellVerticalAlignment::Top => 0f64,
+                    TableCellVerticalAlignment::Bottom => (real_height - size.height).max(0.0),
+                    TableCellVerticalAlignment::Middle => {
+                        (real_height - size.height).max(0.0) / 2.0
+                    }
+                    TableCellVerticalAlignment::Fill => {
+                        if size.height < real_height {
+                            let child_bc =
+                                BoxConstraints::tight(Size::new(size.width, real_height));
+                            let _size = cell.layout(ctx, &child_bc, data, env);
+                        }
+                        0f64
+                    }
+                };
+
+                let child_pos = Point::new(row_width, table_height + dh);
+                cell.set_origin(ctx, data, env, child_pos);
+                row_width += col_widths[col_num];
+            }
+
+            row_starts[row_num] = table_height;
+            table_height += real_height;
+        }
+
+        // Note: Convert col_widths to start offset
+        let mut col_starts = col_widths;
+        let mut col_start = 0f64;
+        for i in 0..col_starts.len() {
+            if i > 0 {
+                col_start += col_border_width;
+            }
+            let width = col_starts[i];
+            col_starts[i] = col_start;
+            col_start += width;
+        }
+
+        self.col_starts = Some(col_starts);
+        self.row_starts = Some(row_starts);
+
+        Size::new(table_width, table_height)
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
+        let mut row_border_width = 0f64;
+        let mut half_row_border_width = 0f64;
+        let mut row_border_color = Color::WHITE; // not used
+        let mut col_border_width = 0f64;
+        let mut half_col_border_width = 0f64;
+        let mut col_border_color = Color::WHITE; // not used
+
+        if let Some(row_border) = &self.row_border {
+            row_border_width = row_border.width.resolve(env);
+            half_row_border_width = row_border_width / 2.0;
+            row_border_color = row_border.color.resolve(env);
+        }
+
+        if let Some(col_border) = &self.col_border {
+            col_border_width = col_border.width.resolve(env);
+            half_col_border_width = col_border_width / 2.0;
+            col_border_color = col_border.color.resolve(env);
+        }
+
+        let size = ctx.size();
+
+        use druid::kurbo::Line;
+
+        if let Some(background) = self.background.as_mut() {
+            let panel = size.to_rect();
+            ctx.with_save(|ctx| {
+                ctx.clip(panel);
+                background.paint(ctx, data, env);
+            });
+        }
+
+        for (row_num, row) in self.children.iter_mut().enumerate() {
+            if row_num > 0 {
+                if row_border_width > 0.0 {
+                    if let Some(ref row_starts) = self.row_starts {
+                        let row_start = row_starts[row_num] - half_row_border_width;
+                        let start = Point::new(0.0, row_start);
+                        let end = Point::new(size.width, row_start);
+                        let line = Line::new(start, end);
+                        ctx.stroke(line, &row_border_color, row_border_width);
+                    }
+                }
+            }
+
+            for (col_num, cell) in row.children.iter_mut().enumerate() {
+                if col_num > 0 {
+                    if col_border_width > 0.0 {
+                        if let Some(ref col_starts) = self.col_starts {
+                            let col_start = col_starts[col_num] - half_col_border_width;
+                            let start = Point::new(col_start, size.height);
+                            let end = Point::new(col_start, 0.0);
+                            let line = Line::new(start, end);
+                            ctx.stroke(line, &col_border_color, col_border_width);
+                        }
+                    }
+                }
+
+                cell.paint(ctx, data, env);
+            }
+        }
+    }
+}

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -54,6 +54,12 @@ pub struct TableRow<T> {
     children: Vec<WidgetPod<T, Box<dyn Widget<T>>>>,
 }
 
+impl<T: Data> Default for TableRow<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T: Data> TableRow<T> {
     /// Create a new, empty table
     pub fn new() -> Self {

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -1,0 +1,103 @@
+// Copyright 2021 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Dietmar Maurer <dietmar@proxmox.com>
+
+use druid::{Data, Widget, WidgetPod};
+
+mod table_column_width;
+pub use table_column_width::*;
+
+mod flex_table;
+pub use flex_table::*;
+
+/// The vertical alignment of the table cell.
+///
+/// If a widget is smaller than the table cell, this determines
+/// where it is positioned.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum TableCellVerticalAlignment {
+    /// Align on the baseline.
+    ///
+    /// Widgets are aligned along the calculated baseline.
+    Baseline,
+    /// Align on top.
+    Top,
+    /// Align on bottom.
+    Bottom,
+    /// Fill the available space.
+    ///
+    /// The height is the size of the largest widget in the table row.
+    /// other widgets must fill that space.
+    Fill,
+    /// Cells are vertically centered.
+    Middle,
+}
+
+/// A table row is a horizontal group of widgets.
+///
+/// All rows in a table must have the same number of children.
+pub struct TableRow<T> {
+    min_height: Option<f64>,
+    vertical_alignment: Option<TableCellVerticalAlignment>,
+    children: Vec<WidgetPod<T, Box<dyn Widget<T>>>>,
+}
+
+impl<T: Data> TableRow<T> {
+    /// Create a new, empty table
+    pub fn new() -> Self {
+        Self {
+            min_height: None,
+            children: Vec::new(),
+            vertical_alignment: None,
+        }
+    }
+
+    /// Builder-style method for specifying the table row minimum height.
+    pub fn min_height(mut self, min_height: f64) -> Self {
+        self.min_height = Some(min_height);
+        self
+    }
+
+    /// Set the table row minimun height.
+    pub fn set_min_height(&mut self, min_height: f64) {
+        self.min_height = Some(min_height);
+    }
+
+    /// Builder-style method for specifying the childrens' [`TableCellVerticalAlignment`].
+    pub fn vertical_alignment(mut self, align: TableCellVerticalAlignment) -> Self {
+        self.vertical_alignment = Some(align);
+        self
+    }
+
+    /// Set the childrens' [`TableCellVerticalAlignment`].
+    pub fn set_vertical_alignment(&mut self, align: TableCellVerticalAlignment) {
+        self.vertical_alignment = Some(align);
+    }
+
+    /// Builder-style variant of [`Self::add_child`].
+    pub fn with_child(mut self, child: impl Widget<T> + 'static) -> Self {
+        self.add_child(child);
+        self
+    }
+
+    /// Add a child widget (table cell).
+    ///
+    /// See also [`Self::with_child`].
+    pub fn add_child(&mut self, child: impl Widget<T> + 'static) {
+        let child: Box<dyn Widget<T>> = Box::new(child);
+        let child = WidgetPod::new(child);
+        self.children.push(child);
+    }
+}

--- a/src/table/table_column_width.rs
+++ b/src/table/table_column_width.rs
@@ -1,0 +1,297 @@
+// Copyright 2021 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Dietmar Maurer <dietmar@proxmox.com>
+
+use std::ops::Range;
+
+/// Simple table column width specification (without minimin and maximum).
+///
+/// If you need minimum/maximum settings use [`ComplexTableColumnWidth`].
+#[derive(Copy, Clone, Debug)]
+pub enum TableColumnWidth {
+    /// Fixed size
+    Fixed(f64),
+    /// Flex layout algorithm.
+    Flex(f64),
+    /// Use a fraction of the total table width.
+    Fraction(f64),
+    /// Maximum of the dimensions of all cells in a column.
+    Intrinsic,
+}
+
+impl TableColumnWidth {
+    fn resolve_width(
+        &self,
+        total_width: f64,
+        intrinsic_width: f64,
+        px_per_flex: f64,
+    ) -> (f64, f64, f64) {
+        match self {
+            Self::Fixed(w) => (*w, *w, 0f64),
+            Self::Flex(f) => (f * px_per_flex, 0f64, *f),
+            Self::Fraction(f) => {
+                let w = f * total_width;
+                (w, w, 0f64)
+            }
+            Self::Intrinsic => (intrinsic_width, intrinsic_width, 0f64),
+        }
+    }
+
+    fn need_intrinsic_width(&self) -> bool {
+        match self {
+            Self::Intrinsic => true,
+            _ => false,
+        }
+    }
+}
+
+impl From<f64> for TableColumnWidth {
+    fn from(fixed_width: f64) -> Self {
+        TableColumnWidth::Fixed(fixed_width)
+    }
+}
+
+/// Table column width with optional minimum and maximum limits.
+///
+/// ```
+/// use druid_widget_nursery::table::{ComplexTableColumnWidth, TableColumnWidth::*};
+///
+/// // flex layout, but with minimum and maximum size
+/// ComplexTableColumnWidth::with_min_max(Flex(1.), Fixed(100.), Fixed(300.));
+///
+/// // flex layout, but use intrinsic size a minimum
+/// ComplexTableColumnWidth::with_min(Flex(1.), Intrinsic);
+/// ```
+///
+/// It is usually not necessary to use this type directly, because
+/// thert are function to convert from:
+///
+/// - f64 => Simple(Fixed(f64))
+/// - `Into<TableColumnWidth>` => Simple(TableColumnWidth))
+/// - `(Into<TableColumnWidth>`, `Range<f64>`) => Limited with min/max from range
+/// - `(Into<TableColumnWidth>`, `Into<TableColumnWidth>`) => Limited with minimun
+/// - `(Into<TableColumnWidth>`, `Into<TableColumnWidth>`, `Into<TableColumnWidth>`) => Limited with min/max
+///
+/// Examples:
+/// ```
+/// use druid_widget_nursery::table::{FlexTable, TableColumnWidth::*};
+/// # fn test () -> FlexTable<()> {
+/// FlexTable::new()
+///    .with_column_width(64.0)
+///    .with_column_width(Intrinsic)
+///    .with_column_width((Flex(1.0), 60.0))
+///    .with_column_width((Flex(1.0), 60.0..200.0))
+/// # }
+/// ```
+#[derive(Copy, Clone, Debug)]
+pub enum ComplexTableColumnWidth {
+    /// Column without limits
+    Simple(TableColumnWidth),
+    /// Limited column (width, min, max)
+    ///
+    /// It is usually better to avoid flex dependent 'min' and 'max'
+    /// constraint, because it can lead to unexpected results (with
+    /// the current resolver).
+    Limited(TableColumnWidth, TableColumnWidth, TableColumnWidth),
+}
+
+impl<W: Into<TableColumnWidth>> From<W> for ComplexTableColumnWidth {
+    fn from(tcw: W) -> Self {
+        let tcw: TableColumnWidth = tcw.into();
+        Self::simple(tcw)
+    }
+}
+
+impl<W: Into<TableColumnWidth>> From<(W, Range<f64>)> for ComplexTableColumnWidth {
+    fn from(data: (W, Range<f64>)) -> Self {
+        let tcw: TableColumnWidth = data.0.into();
+        let min = TableColumnWidth::Fixed(data.1.start);
+        let max = TableColumnWidth::Fixed(data.1.end);
+        Self::with_min_max(tcw, min, max)
+    }
+}
+
+impl<W1, W2> From<(W1, W2)> for ComplexTableColumnWidth
+where
+    W1: Into<TableColumnWidth>,
+    W2: Into<TableColumnWidth>,
+{
+    fn from(data: (W1, W2)) -> Self {
+        let tcw: TableColumnWidth = data.0.into();
+        let min: TableColumnWidth = data.1.into();
+        let max = TableColumnWidth::Fixed(0.0);
+        Self::with_min_max(tcw, min, max)
+    }
+}
+
+impl<W1, W2, W3> From<(W1, W2, W3)> for ComplexTableColumnWidth
+where
+    W1: Into<TableColumnWidth>,
+    W2: Into<TableColumnWidth>,
+    W3: Into<TableColumnWidth>,
+{
+    fn from(data: (W1, W2, W3)) -> Self {
+        let tcw: TableColumnWidth = data.0.into();
+        let min: TableColumnWidth = data.1.into();
+        let max: TableColumnWidth = data.2.into();
+        Self::with_min_max(tcw, min, max)
+    }
+}
+
+impl ComplexTableColumnWidth {
+    /// Create instance without limits
+    pub fn simple(tcw: TableColumnWidth) -> Self {
+        Self::Simple(tcw)
+    }
+
+    /// Create instance with minimum limit
+    pub fn with_min<W1, W2>(tcw: W1, min: W2) -> Self
+    where
+        W1: Into<TableColumnWidth>,
+        W2: Into<TableColumnWidth>,
+    {
+        let tcw: TableColumnWidth = tcw.into();
+        let min: TableColumnWidth = min.into();
+        Self::with_min_max(tcw, min, TableColumnWidth::Fixed(0f64))
+    }
+
+    /// Create instance with maximum limit
+    pub fn with_max<W1, W2>(tcw: W1, max: W2) -> Self
+    where
+        W1: Into<TableColumnWidth>,
+        W2: Into<TableColumnWidth>,
+    {
+        let tcw: TableColumnWidth = tcw.into();
+        let max: TableColumnWidth = max.into();
+        Self::with_min_max(tcw, TableColumnWidth::Fixed(0f64), max)
+    }
+
+    /// Create instance with minimum and maximum limit
+    pub fn with_min_max<W1, W2, W3>(tcw: W1, min: W2, max: W3) -> Self
+    where
+        W1: Into<TableColumnWidth>,
+        W2: Into<TableColumnWidth>,
+        W3: Into<TableColumnWidth>,
+    {
+        let tcw: TableColumnWidth = tcw.into();
+        let min: TableColumnWidth = min.into();
+        let max: TableColumnWidth = max.into();
+        Self::Limited(tcw, min, max)
+    }
+
+    pub(crate) fn need_intrinsic_width(&self) -> bool {
+        match self {
+            Self::Simple(tcw) => tcw.need_intrinsic_width(),
+            Self::Limited(tcw, min, max) => {
+                tcw.need_intrinsic_width()
+                    || min.need_intrinsic_width()
+                    || max.need_intrinsic_width()
+            }
+        }
+    }
+
+    fn resolve_width(
+        &self,
+        total_width: f64,
+        intrinsic_width: f64,
+        px_per_flex: f64,
+        apply_limits: bool,
+    ) -> (bool, f64, f64, f64) {
+        match self {
+            Self::Simple(tcw) => {
+                let (col_width, col_fixed, col_flex) =
+                    tcw.resolve_width(total_width, intrinsic_width, px_per_flex);
+                (false, col_width, col_fixed, col_flex)
+            }
+            Self::Limited(tcw, min, max) => {
+                let (col_width, col_fixed, col_flex) =
+                    tcw.resolve_width(total_width, intrinsic_width, px_per_flex);
+
+                if apply_limits {
+                    let (min_width, _min_fixed, _min_flex) =
+                        min.resolve_width(total_width, intrinsic_width, px_per_flex);
+                    let (max_width, _max_fixed, _max_flex) =
+                        max.resolve_width(total_width, intrinsic_width, px_per_flex);
+
+                    if (max_width > 0f64) && (col_width > max_width) {
+                        return (true, max_width, max_width, 0f64);
+                    }
+                    if (min_width > 0f64) && (col_width < min_width) {
+                        return (true, min_width, min_width, 0f64);
+                    }
+                }
+                (false, col_width, col_fixed, col_flex)
+            }
+        }
+    }
+
+    /// We may use this for several table widget implementations
+    pub(crate) fn compute_column_widths(
+        column_widths: &mut [ComplexTableColumnWidth],
+        intrinsic_widths: &[f64],
+        max_table_width: f64,
+    ) -> Vec<f64> {
+        let column_count = column_widths.len();
+        let mut col_widths = vec![0f64; column_count];
+
+        // Note: This needs only one step unless you use MIN/MAX
+        // column constraints
+        'outer: for _ in 0..column_count {
+            // Step 1: Compute pixels per flex
+
+            let px_per_flex = {
+                let mut fixed_width = 0f64;
+                let mut flex_sum = 0f64;
+
+                for col_num in 0..column_count {
+                    let (_, _width, fixed_share, flex_share) = column_widths[col_num]
+                        .resolve_width(max_table_width, intrinsic_widths[col_num], 0f64, false);
+                    fixed_width += fixed_share;
+                    flex_sum += flex_share;
+                }
+
+                let remaining = (max_table_width - fixed_width).max(0.0);
+                if flex_sum != 0f64 {
+                    remaining / flex_sum
+                } else {
+                    0f64
+                }
+            };
+
+            // Step 2: Apply min/max limits
+
+            for col_num in 0..column_count {
+                let (limit, width, _fixed_share, _flex_share) = column_widths[col_num]
+                    .resolve_width(
+                        max_table_width,
+                        intrinsic_widths[col_num],
+                        px_per_flex,
+                        true,
+                    );
+                col_widths[col_num] = width;
+
+                if limit {
+                    // convert into a fixed size column
+                    column_widths[col_num] = TableColumnWidth::Fixed(width).into();
+                    continue 'outer;
+                }
+            }
+
+            break; // done
+        }
+
+        col_widths
+    }
+}

--- a/src/table/table_column_width.rs
+++ b/src/table/table_column_width.rs
@@ -50,10 +50,7 @@ impl TableColumnWidth {
     }
 
     fn need_intrinsic_width(&self) -> bool {
-        match self {
-            Self::Intrinsic => true,
-            _ => false,
-        }
+        matches!(self, Self::Intrinsic)
     }
 }
 


### PR DESCRIPTION
This is most useful to layout input forms. Provides similar fuctionality
as flutter Table class.

Uses a new module sub-directory ./src/table/, so that it is
possible to add other table implementation there (i.e. DataTable).

Signed-off-by: Dietmar Maurer <dietmar@proxmox.com>