### PR TITLE
Add material icons

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 async = ["tokio/rt", "futures", "flume"]
 derive = ["druid-widget-nursery-derive"]
 hot-reload = ["libloading", "notify5", "rand"]
+material-icons = ["druid-material-icons"]
 
 [dependencies.druid]
 git = "https://github.com/linebender/druid"
@@ -36,10 +37,16 @@ notify5 = { version = "5.0.0-pre.11", optional = true, package = "notify" }
 libloading = { version = "0.6.6", optional = true }
 rand = { version = "0.8.1", optional = true }
 tracing = { version = "0.1.22" }
+druid-material-icons = { version = "0.1.0", optional = true }
 
 [[example]]
 name = "async"
-required-features = ["async", "tokio/rt-multi-thread", "tokio/macros", "tokio/time"]
+required-features = [
+    "async",
+    "tokio/rt-multi-thread",
+    "tokio/macros",
+    "tokio/time",
+]
 
 [[example]]
 name = "animator"
@@ -51,14 +58,14 @@ required-features = ["derive"]
 [[example]]
 name = "splits"
 
+[[example]]
+name = "material_icons"
+required-features = ["material-icons"]
+
 [workspace]
-members = [
-    "druid-widget-nursery-derive",
-    "examples/hot-reload",
-]
+members = ["druid-widget-nursery-derive", "examples/hot-reload"]
 
 [dev-dependencies]
 qu = "0.3.1"
 serde_json = "1.0.71"
 structopt = "0.3.25"
-

--- a/examples/material_icons.rs
+++ b/examples/material_icons.rs
@@ -1,0 +1,37 @@
+use druid::{widget::Flex, AppLauncher, Color, LocalizedString, Widget, WidgetExt, WindowDesc};
+use druid_widget_nursery::material_icons::{
+    normal::action::{ABC, ADD_CARD, ADD_TASK, ADD_TO_DRIVE},
+    Icon,
+};
+use qu::ick_use::*;
+
+// Helps to make the icons visible.
+fn show_icon(icon: impl Widget<()> + 'static) -> impl Widget<()> {
+    icon.padding(10.)
+}
+
+fn ui_builder() -> impl Widget<()> {
+    Flex::row()
+        .with_child(show_icon(Icon::new(ABC)))
+        // if we make it bigger it will preserve aspect ratio if possible
+        .with_child(show_icon(Icon::new(ADD_TASK).fix_width(100.)))
+        // demo non-uniform scale
+        .with_child(show_icon(Icon::new(ADD_CARD).fix_size(24., 100.)))
+        // different color
+        .with_child(show_icon(Icon::new(ADD_TO_DRIVE).with_color(Color::MAROON)))
+        .center()
+}
+
+#[derive(Debug, StructOpt)]
+struct Opt {}
+
+#[qu::ick]
+pub fn main(_opt: Opt) -> Result {
+    // Create the main window
+    let main_window = WindowDesc::new(ui_builder())
+        .title(LocalizedString::new("material-icons").with_placeholder("Material Icons demo"));
+
+    // start the application
+    AppLauncher::with_window(main_window).launch(())?;
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,9 @@ pub mod wedge;
 mod widget_ext;
 pub mod wrap;
 
+#[cfg(feature = "material-icons")]
+pub mod material_icons;
+
 #[cfg(feature = "async")]
 mod future_widget;
 

--- a/src/material_icons.rs
+++ b/src/material_icons.rs
@@ -1,0 +1,71 @@
+pub use druid_material_icons::{normal, IconPaths};
+
+use druid::{
+    kurbo::{Affine, Size},
+    widget::prelude::*,
+    Color, KeyOrValue,
+};
+
+/// A widget that draws one of the material icons.
+///
+/// # Examples
+///
+/// ```
+/// # use druid::Color;
+/// use druid_widget_nursery::material_icons::{Icon, normal::action::ALARM_ADD};
+/// let icon = Icon::new(ALARM_ADD)
+///     // optional - defaults to text color
+///     .with_color(Color::WHITE);
+/// // use `icon` as you would any widget...
+/// ```
+#[derive(Debug, Clone)]
+pub struct Icon {
+    paths: IconPaths,
+    color: KeyOrValue<Color>,
+}
+
+impl Icon {
+    #[inline]
+    pub fn new(paths: IconPaths) -> Self {
+        Self {
+            paths,
+            color: KeyOrValue::from(druid::theme::TEXT_COLOR),
+        }
+    }
+
+    pub fn with_color(mut self, color: impl Into<KeyOrValue<Color>>) -> Self {
+        self.color = color.into();
+        self
+    }
+}
+
+impl<T: Data> Widget<T> for Icon {
+    fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut T, _env: &Env) {
+        // no events
+    }
+    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &T, _env: &Env) {
+        // no lifecycle
+    }
+    fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: &T, _data: &T, _env: &Env) {
+        // no update
+    }
+    fn layout(&mut self, _ctx: &mut LayoutCtx, bc: &BoxConstraints, _data: &T, _env: &Env) -> Size {
+        // Try to preserve aspect ratio if possible, but if not then allow non-uniform scaling.
+        bc.constrain_aspect_ratio(self.paths.size.aspect_ratio(), self.paths.size.width)
+    }
+    fn paint(&mut self, ctx: &mut PaintCtx, _data: &T, env: &Env) {
+        let color = self.color.resolve(env);
+        let Size { width, height } = ctx.size();
+        let Size {
+            width: icon_width,
+            height: icon_height,
+        } = self.paths.size;
+        ctx.transform(Affine::scale_non_uniform(
+            width * icon_width.recip(),
+            height * icon_height.recip(),
+        ));
+        for path in self.paths.paths {
+            ctx.fill(path, &color);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new widget that displays an icon from the [material icons set](https://fonts.google.com/icons). Color is inherited from text color and can optionally be customized. Size defaults to the "given" icon size, but can be changed using constraints. It will prioritize preserving aspect ratio over minimizing difference from the default icon size (I've added an example to demonstrate how to change icons using constraints).

Currently only the normal (my word) icon variants are available. There are also other variants (e.g. two-tone) but I did not include them because the crate size & build time gets quite large. If there is demand I will add them, possibly behind features.