### PR TITLE
Cleanup animation curve

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,9 @@ required-features = [
 name = "animator"
 
 [[example]]
+name = "animation-curves"
+
+[[example]]
 name = "prisms"
 required-features = ["derive"]
 

--- a/examples/animated_value.rs
+++ b/examples/animated_value.rs
@@ -2,7 +2,7 @@ use druid::{
     AppLauncher, BoxConstraints, Color, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx,
     PaintCtx, RenderContext, Size, UnitPoint, UpdateCtx, Widget, WidgetExt, WindowDesc,
 };
-use druid_widget_nursery::animation::{Animated, SimpleCurve};
+use druid_widget_nursery::animation::{Animated, AnimationCurve};
 use druid_widget_nursery::RequestCtx;
 use std::time::Duration;
 
@@ -33,13 +33,13 @@ impl AnimatedWidget {
             color: Animated::new(
                 Color::RED,
                 Duration::from_secs_f64(0.8),
-                SimpleCurve::EaseInOut,
+                AnimationCurve::EASE_IN_OUT,
                 false,
             ),
             insets: Animated::new(
                 6.0,
                 Duration::from_secs_f64(0.2),
-                SimpleCurve::EaseOut,
+                AnimationCurve::EASE_OUT,
                 false,
             ),
             current_color: 0,

--- a/examples/animation-curves.rs
+++ b/examples/animation-curves.rs
@@ -23,7 +23,7 @@ use druid::widget::{Flex, Label};
 use druid::piet::{LineCap, LineJoin, RenderContext, StrokeStyle};
 use druid::kurbo::Line;
 
-use druid_widget_nursery::animation::AnimationCurve;
+use druid_widget_nursery::animation::{Animated, AnimationCurve};
 
 #[derive(Clone, Default, Data)]
 struct AppState;
@@ -95,6 +95,7 @@ pub fn main() {
 /// A widget to display AnimationCurves
 pub struct AnimationCurveGraph {
     curve: AnimationCurve,
+    progress: Animated<f64>,
 }
 
 const AXIS_INSET: f64 = 10.0;
@@ -103,12 +104,31 @@ const CURVE_HEIGHT: f64 = 120.0;
 
 impl AnimationCurveGraph {
     pub fn new(curve: AnimationCurve) -> Self {
-        Self { curve }
+        Self {
+            curve,
+            progress: Animated::new(
+                0.0,
+                std::time::Duration::from_secs_f64(1.0),
+                AnimationCurve::LINEAR,
+                false,
+            ),
+        }
     }
 }
 
 impl<T: Data> Widget<T> for AnimationCurveGraph {
-    fn event(&mut self, _ctx: &mut EventCtx<'_, '_>, _event: &Event, _data: &mut T, _env: &Env) {
+    fn event(&mut self, ctx: &mut EventCtx<'_, '_>, event: &Event, _data: &mut T, _env: &Env) {
+        match event {
+            Event::MouseDown(_) => {
+                self.progress.jump_to_value(0.0);
+                self.progress.animate(ctx, 1.0);
+            }
+            Event::AnimFrame(nanos) => {
+                self.progress.update(*nanos, ctx);
+            }
+            _ => {}
+        }
+
     }
 
     fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx<'_, '_>, _event: &LifeCycle, _data: &T, _env: &Env) {
@@ -118,11 +138,10 @@ impl<T: Data> Widget<T> for AnimationCurveGraph {
     }
 
     fn layout(&mut self, _ctx: &mut LayoutCtx<'_, '_>, _bc: &BoxConstraints, _data: &T, _env: &Env) -> druid::Size {
-        Size::new(CURVE_WIDTH + AXIS_INSET, CURVE_HEIGHT + AXIS_INSET)
+        Size::new(CURVE_WIDTH + 2.0 * AXIS_INSET, CURVE_HEIGHT + 2.0 * AXIS_INSET)
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx<'_, '_, '_>, _data: &T, _env: &Env) {
-
         let axis_color = Color::grey8(140);
 
         let style = StrokeStyle::new()
@@ -150,6 +169,13 @@ impl<T: Data> Widget<T> for AnimationCurveGraph {
             let y1 =  AXIS_INSET + CURVE_HEIGHT - self.curve.translate(((i + 1) as f64)/100.0) * CURVE_HEIGHT;
             let line = Line::new((x0, y0), (x1, y1));
             ctx.stroke_styled(line, &Color::BLUE, 3.0, &style);
+        }
+
+        let progress = self.progress.get();
+        if progress > 0.0 && progress < 1.0 {
+            let anim_y = AXIS_INSET + CURVE_HEIGHT - self.curve.translate(progress) * CURVE_HEIGHT;
+            let line = Line::new((AXIS_INSET / 2.0, anim_y), ( AXIS_INSET + CURVE_WIDTH, anim_y));
+            ctx.stroke_styled(line, &axis_color, 3.0, &style);
         }
     }
 }

--- a/examples/animation-curves.rs
+++ b/examples/animation-curves.rs
@@ -1,0 +1,155 @@
+// Copyright 2022 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Dietmar Maurer <dietmar@proxmox.com>
+
+use druid::{
+    AppLauncher, BoxConstraints, Color, Data, Env, Event, EventCtx, LayoutCtx,
+    LifeCycle, LifeCycleCtx, PaintCtx, Size, UpdateCtx, Widget, WidgetExt,
+    WindowDesc, WindowSizePolicy,
+};
+use druid::widget::{Flex, Label};
+use druid::piet::{LineCap, LineJoin, RenderContext, StrokeStyle};
+use druid::kurbo::Line;
+
+use druid_widget_nursery::animation::AnimationCurve;
+
+#[derive(Clone, Default, Data)]
+struct AppState;
+
+fn build_labeled_graph(
+    label_text: &str,
+    curve: AnimationCurve,
+) -> impl Widget<AppState> {
+    Flex::column()
+        .with_child(Label::new(label_text))
+        .with_child(AnimationCurveGraph::new(curve))
+        .padding((10.0, 10.0, 10.0, 20.0))
+}
+
+fn ui_builder() -> impl Widget<AppState> {
+    Flex::column()
+        .with_child(
+            Flex::row()
+                .with_child(build_labeled_graph("EASE_IN", AnimationCurve::EASE_IN))
+                .with_child(build_labeled_graph("EASE_OUT", AnimationCurve::EASE_OUT))
+                .with_child(build_labeled_graph("EASE_IN_OUT", AnimationCurve::EASE_IN_OUT))
+        )
+        .with_child(
+            Flex::row()
+                .with_child(build_labeled_graph("EASE_IN_EXPO", AnimationCurve::EASE_IN_EXPO))
+                .with_child(build_labeled_graph("EASE_OUT_EXPO", AnimationCurve::EASE_OUT_EXPO))
+                .with_child(build_labeled_graph("EASE_IN_OUT_EXPO", AnimationCurve::EASE_IN_OUT_EXPO))
+        )
+        .with_child(
+            Flex::row()
+                .with_child(build_labeled_graph("BOUNCE_IN", AnimationCurve::BOUNCE_IN))
+                .with_child(build_labeled_graph("BOUNCE_OUT", AnimationCurve::BOUNCE_OUT))
+                .with_child(build_labeled_graph("BOUNCE_IN_OUT", AnimationCurve::BOUNCE_IN_OUT))
+        )
+        .with_child(
+            Flex::row()
+                .with_child(build_labeled_graph("EASE_IN_SINE", AnimationCurve::EASE_IN_SINE))
+                .with_child(build_labeled_graph("EASE_OUT_SINE", AnimationCurve::EASE_OUT_SINE))
+                .with_child(build_labeled_graph("EASE_IN_OUT_SINE", AnimationCurve::EASE_IN_OUT_SINE))
+        )
+        .with_child(
+            Flex::row()
+                .with_child(build_labeled_graph("EASE_IN_ELASTIC", AnimationCurve::EASE_IN_ELASTIC))
+                .with_child(build_labeled_graph("EASE_OUT_ELASTIC", AnimationCurve::EASE_OUT_ELASTIC))
+                .with_child(build_labeled_graph("EASE_IN_OUT_ELASTIC", AnimationCurve::EASE_IN_OUT_ELASTIC))
+        )
+        .with_child(
+            Flex::row()
+                .with_child(build_labeled_graph("EASE_IN_BACK", AnimationCurve::EASE_IN_BACK))
+                .with_child(build_labeled_graph("EASE_OUT_BACK", AnimationCurve::EASE_OUT_BACK))
+                .with_child(build_labeled_graph("EASE_IN_OUT_BACK", AnimationCurve::EASE_IN_OUT_BACK))
+        )
+}
+
+pub fn main() {
+    let main_window = WindowDesc::new(ui_builder())
+        .window_size_policy(WindowSizePolicy::Content)
+        .title("Show Animation Curves");
+
+    let state = AppState;
+
+    AppLauncher::with_window(main_window)
+        .log_to_console()
+        .launch(state)
+        .expect("launch failed");
+}
+
+
+/// A widget to display AnimationCurves
+pub struct AnimationCurveGraph {
+    curve: AnimationCurve,
+}
+
+const AXIS_INSET: f64 = 10.0;
+const CURVE_WIDTH: f64 = 300.0;
+const CURVE_HEIGHT: f64 = 120.0;
+
+impl AnimationCurveGraph {
+    pub fn new(curve: AnimationCurve) -> Self {
+        Self { curve }
+    }
+}
+
+impl<T: Data> Widget<T> for AnimationCurveGraph {
+    fn event(&mut self, _ctx: &mut EventCtx<'_, '_>, _event: &Event, _data: &mut T, _env: &Env) {
+    }
+
+    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx<'_, '_>, _event: &LifeCycle, _data: &T, _env: &Env) {
+    }
+
+    fn update(&mut self, _ctx: &mut UpdateCtx<'_, '_>, _old_data: &T, _data: &T, _env: &Env) {
+    }
+
+    fn layout(&mut self, _ctx: &mut LayoutCtx<'_, '_>, _bc: &BoxConstraints, _data: &T, _env: &Env) -> druid::Size {
+        Size::new(CURVE_WIDTH + AXIS_INSET, CURVE_HEIGHT + AXIS_INSET)
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx<'_, '_, '_>, _data: &T, _env: &Env) {
+
+        let axis_color = Color::grey8(140);
+
+        let style = StrokeStyle::new()
+            .line_cap(LineCap::Round)
+            .line_join(LineJoin::Round);
+
+        let line = Line::new((AXIS_INSET, AXIS_INSET / 2.0), ( AXIS_INSET, CURVE_HEIGHT + AXIS_INSET * 1.5));
+        ctx.stroke_styled(line, &axis_color, 3.0, &style);
+        let line = Line::new((AXIS_INSET / 2.0, CURVE_HEIGHT + AXIS_INSET), (AXIS_INSET + CURVE_WIDTH, CURVE_HEIGHT + AXIS_INSET));
+        ctx.stroke_styled(line, &axis_color, 3.0, &style);
+
+        let dashed_style = StrokeStyle::new()
+            .dash_pattern(&[5.0, 5.0])
+            .line_cap(LineCap::Round)
+            .line_join(LineJoin::Round);
+
+        let line = Line::new((AXIS_INSET / 2.0, AXIS_INSET), (AXIS_INSET + CURVE_WIDTH, AXIS_INSET));
+        ctx.stroke_styled(line, &axis_color, 3.0, &dashed_style);
+
+        let dx = CURVE_WIDTH / 100.0;
+        for i in 0..100 {
+            let x0 =  AXIS_INSET + (i as f64) * dx;
+            let x1 = x0 + dx;
+            let y0 =  AXIS_INSET + CURVE_HEIGHT - self.curve.translate((i as f64)/100.0) *  CURVE_HEIGHT;
+            let y1 =  AXIS_INSET + CURVE_HEIGHT - self.curve.translate(((i + 1) as f64)/100.0) * CURVE_HEIGHT;
+            let line = Line::new((x0, y0), (x1, y1));
+            ctx.stroke_styled(line, &Color::BLUE, 3.0, &style);
+        }
+    }
+}

--- a/examples/animator.rs
+++ b/examples/animator.rs
@@ -6,13 +6,37 @@ use druid::{
     theme, AppLauncher, BoxConstraints, Color, Data, Env, Event, EventCtx, LayoutCtx, Lens,
     LifeCycle, LifeCycleCtx, PaintCtx, UpdateCtx, Widget, WindowDesc,
 };
-use druid_widget_nursery::animation::{AnimationDirection, AnimationId, Animator, SimpleCurve};
+use druid_widget_nursery::animation::{AnimationDirection, AnimationId, Animator, AnimationCurve};
 
 use druid::widget::prelude::RenderContext;
 use std::time::Duration;
 
+#[derive(Data, Clone, Copy, PartialEq)]
+enum Curve {
+    Linear,
+    EaseIn,
+    EaseOut,
+    EaseInOut,
+    EaseOutElastic,
+    BounceOut,
+    EaseOutSine,
+}
+
+impl From<Curve> for AnimationCurve {
+    fn from(curve: Curve) -> AnimationCurve {
+        match curve {
+            Curve::Linear => AnimationCurve::LINEAR,
+            Curve::EaseIn => AnimationCurve::EASE_IN,
+            Curve::EaseOut => AnimationCurve::EASE_OUT,
+            Curve::EaseInOut => AnimationCurve::EASE_IN_OUT,
+            Curve::EaseOutElastic => AnimationCurve::EASE_OUT_ELASTIC,
+            Curve::BounceOut => AnimationCurve::BOUNCE_OUT,
+            Curve::EaseOutSine => AnimationCurve::EASE_OUT_SINE,
+        }
+    }
+}
+
 fn main_widget() -> impl Widget<AnimState> {
-    use SimpleCurve::*;
     fn group<T: Data>(t: impl Into<LabelText<T>>, w: impl Widget<T> + 'static) -> impl Widget<T> {
         Flex::column()
             .cross_axis_alignment(CrossAxisAlignment::Start)
@@ -31,13 +55,13 @@ fn main_widget() -> impl Widget<AnimState> {
         .with_child(group(
             "Curve",
             RadioGroup::new(vec![
-                ("Linear", Linear),
-                ("EaseIn", EaseIn),
-                ("EaseOut", EaseOut),
-                ("EaseInOut", EaseInOut),
-                ("OutElastic", OutElastic),
-                ("OutBounce", OutBounce),
-                ("OutSine", OutSine),
+                ("Linear", Curve::Linear),
+                ("EaseIn", Curve::EaseIn),
+                ("EaseOut", Curve::EaseOut),
+                ("EaseInOut", Curve::EaseInOut),
+                ("EaseOutElastic", Curve::EaseOutElastic),
+                ("BounceOut", Curve::BounceOut),
+                ("EaseOutSine", Curve::EaseOutSine),
             ])
             .lens(AnimState::curve),
         ))
@@ -92,7 +116,7 @@ fn main() {
 
     // create the initial app state
     let initial_state = AnimState {
-        curve: SimpleCurve::Linear,
+        curve: Curve::Linear,
         duration: Some(1000),
         direction: AnimationDirection::Forward,
         toggle_size: false,
@@ -109,7 +133,7 @@ fn main() {
 
 #[derive(Clone, Data, Lens)]
 struct AnimState {
-    curve: SimpleCurve,
+    curve: Curve,
     duration: Option<usize>,
     direction: AnimationDirection,
     repeat_limit: Option<usize>,

--- a/src/animation/curve.rs
+++ b/src/animation/curve.rs
@@ -1,3 +1,17 @@
+// Copyright 2019 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::f64::consts::PI;
@@ -8,11 +22,20 @@ impl From<fn(f64) -> f64> for AnimationCurve {
     }
 }
 
+/// Animation Curve
+///
 /// An animation curve, mapping from time in the range 0..1 to progress in a range "around" 0..1.
 /// It is permissible for progress to undershoot and overshoot.
+///
+/// Inspired by Robert Penner’s [easing] functions.
+///
+/// [easing]: http://robertpenner.com/easing/
 pub enum AnimationCurve {
+    /// Defined with constant function.
     Function(fn(f64) -> f64),
+    /// Defined with closure.
     Closure(Box<dyn FnMut(f64) -> f64>),
+    /// Defined as Cubic Bezier curve.
     CubicBezier(CubicBezierAnimationCurve),
     //    Spring(SpringAnimationCurve),
 }
@@ -36,10 +59,10 @@ impl Debug for AnimationCurve {
                 .finish(),
             AnimationCurve::CubicBezier(b) => formatter
                 .debug_struct("AnimationCurve::CubicBezier")
-                .field("a", &b.a)
-                .field("b", &b.b)
-                .field("c", &b.c)
-                .field("d", &b.d)
+                .field("x1", &b.x1)
+                .field("y1", &b.y1)
+                .field("x2", &b.x2)
+                .field("y2", &b.y2)
                 .finish(),
         }
     }
@@ -47,36 +70,58 @@ impl Debug for AnimationCurve {
 
 impl AnimationCurve {
 
+    /// F(t) -> t
     pub const LINEAR: Self = Self::Function(|t| t);
 
+    /// F(t) -> t²
     pub const EASE_IN: Self = Self::Function(ease_in);
+    /// Flipped  [`EASE_IN`](AnimationCurve::EASE_IN)
     pub const EASE_OUT: Self = Self::Function(|t| flip_curve(ease_in, t));
+    /// combines [`EASE_IN`](AnimationCurve::EASE_IN) and [`EASE_OUT`](AnimationCurve::EASE_OUT)
     pub const EASE_IN_OUT: Self = Self::Function(|t| combine_in_out(ease_in, t));
 
+    /// Oscillating curve that grows in magnitude while overshooting its bounds.
     pub const EASE_IN_ELASTIC: Self = Self::Function(|t| flip_curve(ease_out_elastic, t));
+    /// Oscillating curve that shrink in magnitude while overshooting its bounds.
     pub const EASE_OUT_ELASTIC: Self = Self::Function(ease_out_elastic);
+    /// Oscillating curve that grows and then shrinks in magnitude
+    /// while overshooting its bounds.
     pub const EASE_IN_OUT_ELASTIC: Self = Self::Function(|t| combine_in_out_rev(ease_out_elastic, t));
 
+    /// F(t) -> 1 - cos(tπ/2)
     pub const EASE_IN_SINE: Self = Self::Function(|t| 1.0 - (t * PI * 0.5).cos());
+    /// F(t) -> sin(tπ/2)
     pub const EASE_OUT_SINE: Self = Self::Function(|t| (t * PI * 0.5).sin());
+    /// combines [`EASE_IN_SINE`](AnimationCurve::EASE_IN_SINE) and [`EASE_OUT_SINE`](AnimationCurve::EASE_OUT_SINE)
     pub const EASE_IN_OUT_SINE: Self = Self::Function(|t| -0.5 * (t * PI).cos() + 0.5);
 
+    /// F(t) -> 2¹⁰⁽ᵗ⁻¹⁾
     pub const EASE_IN_EXPO: Self = Self::Function(ease_in_expo);
+    ///  Flipped  [`EASE_IN_EXPO`](AnimationCurve::EASE_IN_EXPO)
     pub const EASE_OUT_EXPO: Self = Self::Function(|t| flip_curve(ease_in_expo, t));
+    /// combines [`EASE_IN_EXPO`](AnimationCurve::EASE_IN_EXPO) and [`EASE_OUT_EXPO`](AnimationCurve::EASE_OUT_EXPO)
     pub const EASE_IN_OUT_EXPO: Self = Self::Function(|t| combine_in_out(ease_in_expo, t));
 
+    /// A Cubic curve that undershoots slowly a start and ends quickly.
     pub const EASE_IN_BACK: Self = Self::cubic(0.36, 0.0, 0.66, -0.56);
+    /// A Cubic curve that starts quickly and ends with slowly, with an overshoot at the end.
     pub const EASE_OUT_BACK: Self = Self::cubic(0.34, 1.56, 0.64, 1.0);
+    /// combines [`EASE_IN_BACK`](AnimationCurve::EASE_IN_BACK) and [`EASE_OUT_BACK`](AnimationCurve::EASE_OUT_BACK)
     pub const EASE_IN_OUT_BACK: Self = Self::cubic(0.68, -0.6, 0.32, 1.6);
 
+    /// Oscillating curve that grows larger, mimicking a bounce effect
     pub const BOUNCE_IN: Self = Self::Function(|t| flip_curve(bounce, t));
+    /// Flipped [`BOUNCE_IN`](AnimationCurve::BOUNCE_IN)
     pub const BOUNCE_OUT: Self = Self::Function(bounce);
+    /// combines [`BOUNCE_IN`](AnimationCurve::BOUNCE_IN) and [`BOUNCE_OUT`](AnimationCurve::BOUNCE_OUT)
     pub const BOUNCE_IN_OUT: Self = Self::Function(|t|  combine_in_out_rev(bounce, t));
 
-    pub const fn cubic(a: f64, b: f64, c: f64, d: f64) -> Self {
-        Self::CubicBezier(CubicBezierAnimationCurve { a, b, c, d })
+    /// Create a Cubic Bezier curve.
+    pub const fn cubic(x1: f64, y1: f64, x2: f64, y2: f64) -> Self {
+        Self::CubicBezier(CubicBezierAnimationCurve { x1, y1, x2, y2 })
     }
 
+    /// Returns the value of the curve at point `t`.
     pub fn translate(&mut self, t: f64) -> f64 {
         match self {
             Self::Function(f) => f(t),
@@ -85,16 +130,33 @@ impl AnimationCurve {
         }
     }
 
+    /// Create an instance with the given closure.
     pub fn from_closure(f: impl FnMut(f64) -> f64 + 'static) -> AnimationCurve {
         AnimationCurve::Closure(Box::new(f))
     }
 }
 
+/// A [Cubic Bezier] curve where P0 is (0, 0) and P3 is (1, 1)
+///
+/// This is normally used with [AnimationCurve], for eaxple:
+///
+/// ```
+/// use druid_widget_nursery::animation::AnimationCurve;
+///
+/// let curve = AnimationCurve::cubic(0.68, -0.6, 0.32, 1.6);
+///
+/// ```
+///
+/// [Cubic Bezier]: https://en.wikipedia.org/wiki/B%C3%A9zier_curve
 pub struct CubicBezierAnimationCurve {
-    pub a: f64,
-    pub b: f64,
-    pub c: f64,
-    pub d: f64,
+    /// X coordinate of P1
+    pub x1: f64,
+    /// Y coordinate of P1
+    pub y1: f64,
+    /// X coordinate of P2
+    pub x2: f64,
+    /// Y coordinate of P2
+    pub y2: f64,
 }
 
 impl CubicBezierAnimationCurve {
@@ -105,6 +167,7 @@ impl CubicBezierAnimationCurve {
                                           m * m * m
     }
 
+    /// Returns the value of the curve at point `t`.
     pub fn translate(&self, t: f64) -> f64 {
         let mut start = 0.0;
         let mut end = 1.0;
@@ -113,9 +176,9 @@ impl CubicBezierAnimationCurve {
 
         loop {
             let midpoint = (start + end) / 2.0;
-            let estimate = Self::evaluate_cubic(self.a, self.c, midpoint);
+            let estimate = Self::evaluate_cubic(self.x1, self.x2, midpoint);
             if (t - estimate).abs() < CUBIC_ERROR_BOUND {
-                return Self::evaluate_cubic(self.b, self.d, midpoint);
+                return Self::evaluate_cubic(self.y1, self.y2, midpoint);
             }
             if estimate < t {
                 start = midpoint;

--- a/src/animation/curve.rs
+++ b/src/animation/curve.rs
@@ -1,135 +1,101 @@
 use std::fmt;
 use std::fmt::{Debug, Formatter};
-
-use druid::Data;
-
-/// A custom animation curve mapping from time in the range 0..1 to progress in a range "around" 0..1.
-/// It is permissible to undershoot and overshoot.
-pub enum CustomCurve {
-    Function(fn(f64) -> f64),
-    Closure(Box<dyn FnMut(f64) -> f64>),
-}
-
-impl CustomCurve {
-    fn translate(&mut self, t: f64) -> f64 {
-        match self {
-            CustomCurve::Function(f) => f(t),
-            CustomCurve::Closure(f) => f(t),
-        }
-    }
-}
-
-impl Debug for CustomCurve {
-    // Required as closures are not Debug
-    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            CustomCurve::Function(f) => formatter
-                .debug_struct("CustomAnimationCurve::Function")
-                .field("f", f)
-                .finish(),
-            CustomCurve::Closure(_) => formatter
-                .debug_struct("CustomAnimationCurve::Closure")
-                .finish(),
-        }
-    }
-}
+use std::f64::consts::PI;
 
 impl From<fn(f64) -> f64> for AnimationCurve {
     fn from(f: fn(f64) -> f64) -> Self {
-        AnimationCurve::Custom(CustomCurve::Function(f))
+        AnimationCurve::Function(f)
     }
 }
 
-impl From<SimpleCurve> for AnimationCurve {
-    fn from(s: SimpleCurve) -> Self {
-        AnimationCurve::Simple(s)
-    }
-}
-
-#[derive(Data, Copy, Clone, Debug, Eq, PartialEq)]
-/// A simple built in animation curve
-pub enum SimpleCurve {
-    Linear,
-    EaseIn,
-    EaseOut,
-    EaseInOut,
-    OutElastic,
-    OutBounce,
-    OutSine,
-}
-
-impl SimpleCurve {
-    fn translate(&mut self, t: f64) -> f64 {
-        use std::f64::consts::PI;
-        match self {
-            Self::Linear => t,
-            Self::EaseIn => t * t,
-            Self::EaseOut => t * (2.0 - t),
-            Self::EaseInOut => {
-                let t = t * 2.0;
-                if t < 1. {
-                    0.5 * t * t
-                } else {
-                    let t = t - 1.;
-                    -0.5 * (t * (t - 2.) - 1.)
-                }
-            }
-            Self::OutElastic => {
-                let p = 0.3;
-                let s = p / 4.0;
-
-                if t < 0.001 {
-                    0.
-                } else if t > 0.999 {
-                    1.
-                } else {
-                    2.0f64.powf(-10.0 * t) * ((t - s) * (2.0 * PI) / p).sin() + 1.0
-                }
-            }
-            Self::OutSine => (t * PI * 0.5).sin(),
-            Self::OutBounce => {
-                if t < (1. / 2.75) {
-                    7.5625 * t * t
-                } else if t < (2. / 2.75) {
-                    let t = t - (1.5 / 2.75);
-                    7.5625 * t * t + 0.75
-                } else if t < (2.5 / 2.75) {
-                    let t = t - (2.25 / 2.75);
-                    7.5625 * t * t + 0.9375
-                } else {
-                    let t = t - (2.625 / 2.75);
-                    7.5625 * t * t + 0.984375
-                }
-            }
-        }
-    }
-}
-
-#[derive(Debug)]
 /// An animation curve, mapping from time in the range 0..1 to progress in a range "around" 0..1.
 /// It is permissible for progress to undershoot and overshoot.
 pub enum AnimationCurve {
-    Simple(SimpleCurve),
+    Function(fn(f64) -> f64),
+    Closure(Box<dyn FnMut(f64) -> f64>),
     //    CubicBezier(CubicBezierAnimationCurve),
     //    Spring(SpringAnimationCurve),
-    Custom(CustomCurve),
 }
 
 impl Default for AnimationCurve {
     fn default() -> Self {
-        AnimationCurve::Simple(SimpleCurve::Linear)
+        AnimationCurve::LINEAR
+    }
+}
+
+impl Debug for AnimationCurve {
+    // Required as closures are not Debug
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            AnimationCurve::Function(f) => formatter
+                .debug_struct("AnimationCurve::Function")
+                .field("f", f)
+                .finish(),
+            AnimationCurve::Closure(_) => formatter
+                .debug_struct("AnimationCurve::Closure")
+                .finish(),
+        }
     }
 }
 
 impl AnimationCurve {
+
+    pub const LINEAR: Self = Self::Function(|t| t);
+
+    pub const EASE_IN: Self = Self::Function(|t| t * t);
+
+    pub const EASE_OUT: Self = Self::Function(|t| t * (2.0 - t));
+
+    pub const EASE_IN_OUT: Self = Self::Function(|t| {
+        let t = t * 2.0;
+        if t < 1. {
+            0.5 * t * t
+        } else {
+            let t = t - 1.;
+            -0.5 * (t * (t - 2.) - 1.)
+        }
+    });
+
+    pub const EASE_OUT_ELASTIC: Self = Self::Function(|t| {
+        let p = 0.3;
+        let s = p / 4.0;
+
+        if t < 0.001 {
+            0.
+        } else if t > 0.999 {
+            1.
+        } else {
+            2.0f64.powf(-10.0 * t) * ((t - s) * (2.0 * PI) / p).sin() + 1.0
+        }
+    });
+
+    pub const EASE_OUT_SINE: Self = Self::Function(|t| (t * PI * 0.5).sin());
+
+    pub const BOUNCE_OUT: Self = Self::Function(|t| bounce(t));
+
     pub fn translate(&mut self, t: f64) -> f64 {
         match self {
-            Self::Simple(s) => s.translate(t),
-            Self::Custom(c) => c.translate(t),
+            Self::Function(f) => f(t),
+            Self::Closure(c) => c(t),
         }
     }
 
     pub fn from_closure(f: impl FnMut(f64) -> f64 + 'static) -> AnimationCurve {
-        AnimationCurve::Custom(CustomCurve::Closure(Box::new(f)))
+        AnimationCurve::Closure(Box::new(f))
+    }
+}
+
+fn bounce(t: f64) -> f64 {
+    if t < (1. / 2.75) {
+        7.5625 * t * t
+    } else if t < (2. / 2.75) {
+        let t = t - (1.5 / 2.75);
+        7.5625 * t * t + 0.75
+    } else if t < (2.5 / 2.75) {
+        let t = t - (2.25 / 2.75);
+        7.5625 * t * t + 0.9375
+    } else {
+        let t = t - (2.625 / 2.75);
+        7.5625 * t * t + 0.984375
     }
 }

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -10,7 +10,7 @@ mod test;
 pub use animated_value::{Animated, Interpolate};
 pub use animator::Animator;
 pub use context::AnimationCtx;
-pub use curve::{AnimationCurve, CustomCurve, SimpleCurve};
+pub use curve::AnimationCurve;
 pub use storage::AnimationId;
 
 use druid::Data;

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -1,3 +1,5 @@
+//! Druid animation library
+
 mod animated_value;
 mod animator;
 mod context;
@@ -10,7 +12,7 @@ mod test;
 pub use animated_value::{Animated, Interpolate};
 pub use animator::Animator;
 pub use context::AnimationCtx;
-pub use curve::AnimationCurve;
+pub use curve::{AnimationCurve, CubicBezierAnimationCurve};
 pub use storage::AnimationId;
 
 use druid::Data;

--- a/src/multi_value.rs
+++ b/src/multi_value.rs
@@ -1,4 +1,4 @@
-use crate::animation::{Animated, AnimationCurve, Interpolate, SimpleCurve};
+use crate::animation::{Animated, AnimationCurve, Interpolate};
 use crate::prism::{DisablePrismWrap, OptionSome, Prism};
 use druid::theme::WIDGET_PADDING_VERTICAL;
 use druid::widget::{Checkbox, Radio};
@@ -372,7 +372,7 @@ impl IndentLayout {
             height: Animated::new(
                 0.0,
                 Duration::from_secs_f64(0.2),
-                SimpleCurve::EaseOut,
+                AnimationCurve::EASE_OUT,
                 true,
             ),
         }


### PR DESCRIPTION
I think it is a good idea to remove the nested `AnimationCurve`subtypes `SimpleCurve` and `CustomCurve`. We can do everything without them.

I will add more documentation if this is considered for a merge ...