### PR TITLE
Consider content insets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ material-icons = ["druid-material-icons"]
 
 [dependencies.druid]
 git = "https://github.com/linebender/druid"
-rev = "2f5beb8faba648c170a485b8d6a00d0d991a1737" # update this when upgrading to newer druid
+rev = "fc05e965c85fced8720c655685e02478e0530e94" # update this when upgrading to newer druid
 # path = "../../projects/druid/druid"
 features = ["im"]
 

--- a/src/dropdown.rs
+++ b/src/dropdown.rs
@@ -33,7 +33,12 @@ impl<T: Data> Dropdown<T> {
 
     fn show_dropdown(&mut self, data: &mut T, env: &Env, ctx: &mut EventCtx) {
         let widget = (self.drop)(data, env);
-        let origin = ctx.to_window(Point::new(0., ctx.size().height));
+        let mut origin = ctx.to_window(Point::new(0., ctx.size().height));
+
+        let insets = ctx.window().content_insets();
+        origin.x += insets.x0;
+        origin.y += insets.y0;
+
         self.window = Some(
             ctx.new_sub_window(
                 WindowConfig::default()


### PR DESCRIPTION
This finally fixes the dropdown position on gtk/linux. This needs latest druid with:

https://github.com/linebender/druid/pull/2117

