### PR TITLE
Fix issue building with qu.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,6 @@ required-features = ["material-icons"]
 members = ["druid-widget-nursery-derive", "examples/hot-reload"]
 
 [dev-dependencies]
-qu = "0.3.1"
+clap = { version = "3.2.19", features = ["derive"] }
+qu = "0.5.1"
 serde_json = "1.0.71"
-structopt = "0.3.25"

--- a/examples/json_viewer.rs
+++ b/examples/json_viewer.rs
@@ -192,9 +192,8 @@ impl AppDelegate<JsonNode> for Delegate {
     }
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Opt {
-    #[structopt(parse(from_os_str))]
     json_file: Option<PathBuf>,
 }
 

--- a/examples/material_icons.rs
+++ b/examples/material_icons.rs
@@ -22,11 +22,8 @@ fn ui_builder() -> impl Widget<()> {
         .center()
 }
 
-#[derive(Debug, StructOpt)]
-struct Opt {}
-
 #[qu::ick]
-pub fn main(_opt: Opt) -> Result {
+pub fn main() -> Result {
     // Create the main window
     let main_window = WindowDesc::new(ui_builder())
         .title(LocalizedString::new("material-icons").with_placeholder("Material Icons demo"));

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -44,7 +44,7 @@ pub enum AnimationStatus {
 }
 
 /// Which direction should the animation run, and how should it repeat
-#[derive(Debug, Data, Copy, Clone, PartialOrd, PartialEq)]
+#[derive(Debug, Data, Copy, Clone, PartialOrd, Eq, PartialEq)]
 pub enum AnimationDirection {
     Forward,
     Reverse,

--- a/src/dropdown.rs
+++ b/src/dropdown.rs
@@ -7,8 +7,10 @@ use druid::WindowSizePolicy;
 use druid::{Point, WindowConfig};
 use druid::{WindowId, WindowLevel};
 
+type DropFn<T> = Box<dyn Fn(&T, &Env) -> Box<dyn Widget<T>>>;
+
 pub struct Dropdown<T> {
-    drop: Box<dyn Fn(&T, &Env) -> Box<dyn Widget<T>>>,
+    drop: DropFn<T>,
     window: Option<WindowId>,
 }
 

--- a/src/mask.rs
+++ b/src/mask.rs
@@ -19,13 +19,14 @@ use druid::{
 };
 use druid::widget::{Align, BackgroundBrush, Flex, Label, LabelText, Spinner};
 
+type ShowMaskFn<T> = Box<dyn Fn(&T, &Env) -> bool>;
 
 /// A widget that conditionally masks the child content and displays
 /// other content instead (the mask).
 pub struct Mask<T> {
     child: WidgetPod<T, Box<dyn Widget<T>>>,
     mask: WidgetPod<T, Box<dyn Widget<T>>>,
-    show_mask_cb: Option<Box<dyn Fn(&T, &Env) -> bool>>,
+    show_mask_cb: Option<ShowMaskFn<T>>,
     show_mask: bool,
 }
 

--- a/src/on_change.rs
+++ b/src/on_change.rs
@@ -1,6 +1,7 @@
 use druid::widget::prelude::*;
 use druid::widget::Controller;
 
+#[allow(clippy::type_complexity)]
 pub struct OnChange<T>(Box<dyn Fn(&mut EventCtx, &T, &mut T, &Env)>);
 
 impl<T> OnChange<T> {

--- a/src/on_cmd.rs
+++ b/src/on_cmd.rs
@@ -2,9 +2,11 @@ use druid::widget::prelude::*;
 use druid::widget::Controller;
 use druid::Selector;
 
+type HandlerFn<CT, WT> = Box<dyn Fn(&mut EventCtx, &CT, &mut WT)>;
+
 pub struct OnCmd<CT, WT> {
     selector: Selector<CT>,
-    handler: Box<dyn Fn(&mut EventCtx, &CT, &mut WT)>,
+    handler: HandlerFn<CT, WT>,
 }
 
 impl<CT, WT> OnCmd<CT, WT> {

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -26,7 +26,7 @@ pub use flex_table::*;
 ///
 /// If a widget is smaller than the table cell, this determines
 /// where it is positioned.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum TableCellVerticalAlignment {
     /// Align on the baseline.
     ///

--- a/src/theme_loader/mod.rs
+++ b/src/theme_loader/mod.rs
@@ -178,7 +178,7 @@ impl From<std::io::Error> for ThemeLoadError {
 /// the actual values yet, pending validation.
 ///
 /// [`Value`]: druid::Value
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ValueKind {
     Color,
     Float,


### PR DESCRIPTION
This fixes building the examples. The problem comes from how `clap` has superseded `structopt` for derived argument parsing.

Closes #118 