### PR TITLE
Stack based tooltips v3

### DIFF
--- a/examples/stack_tooltip.rs
+++ b/examples/stack_tooltip.rs
@@ -39,6 +39,7 @@ fn main() {
                         Label::new("MID LEFT"),
                         String::from("TOOLTIP LOREM IPSUM DORUM"),
                     )
+                    .with_crosshair(true)
                     .cancel_stack_tooltip(),
                 )
                 .with_flex_spacer(1.0)

--- a/src/stack_tooltip.rs
+++ b/src/stack_tooltip.rs
@@ -606,12 +606,12 @@ impl Clone for YetAnotherAttribute {
             Self::UnresolvedStyle(attr) => Self::UnresolvedStyle(attr.clone()),
             Self::Resolved(attr) => Self::Resolved(match attr {
                 TextAttribute::FontFamily(val) => TextAttribute::FontFamily(val.clone()),
-                TextAttribute::FontSize(val) => TextAttribute::FontSize(val.clone()),
-                TextAttribute::Weight(val) => TextAttribute::Weight(val.clone()),
+                TextAttribute::FontSize(val) => TextAttribute::FontSize(*val),
+                TextAttribute::Weight(val) => TextAttribute::Weight(*val),
                 TextAttribute::TextColor(val) => TextAttribute::TextColor(val.clone()),
-                TextAttribute::Style(val) => TextAttribute::Style(val.clone()),
-                TextAttribute::Underline(val) => TextAttribute::Underline(val.clone()),
-                TextAttribute::Strikethrough(val) => TextAttribute::Strikethrough(val.clone()),
+                TextAttribute::Style(val) => TextAttribute::Style(*val),
+                TextAttribute::Underline(val) => TextAttribute::Underline(*val),
+                TextAttribute::Strikethrough(val) => TextAttribute::Strikethrough(*val),
             }),
         }
     }

--- a/src/stack_tooltip.rs
+++ b/src/stack_tooltip.rs
@@ -529,7 +529,6 @@ impl From<RichText> for PlainOrRich {
     }
 }
 
-#[derive(Clone)]
 enum YetAnotherAttribute {
     Unresolved(Attribute),
     UnresolvedFamily(Attribute),
@@ -594,5 +593,26 @@ impl TryFrom<Attribute> for YetAnotherAttribute {
         };
     
         Ok(res)
+    }
+}
+
+impl Clone for YetAnotherAttribute {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Unresolved(attr) => Self::Unresolved(attr.clone()),
+            Self::UnresolvedFamily(attr) => Self::UnresolvedFamily(attr.clone()),
+            Self::UnresolvedSize(attr) => Self::UnresolvedSize(attr.clone()),
+            Self::UnresolvedWeight(attr) => Self::UnresolvedWeight(attr.clone()),
+            Self::UnresolvedStyle(attr) => Self::UnresolvedStyle(attr.clone()),
+            Self::Resolved(attr) => Self::Resolved(match attr {
+                TextAttribute::FontFamily(val) => TextAttribute::FontFamily(val.clone()),
+                TextAttribute::FontSize(val) => TextAttribute::FontSize(val.clone()),
+                TextAttribute::Weight(val) => TextAttribute::Weight(val.clone()),
+                TextAttribute::TextColor(val) => TextAttribute::TextColor(val.clone()),
+                TextAttribute::Style(val) => TextAttribute::Style(val.clone()),
+                TextAttribute::Underline(val) => TextAttribute::Underline(val.clone()),
+                TextAttribute::Strikethrough(val) => TextAttribute::Strikethrough(val.clone()),
+            }),
+        }
     }
 }

--- a/src/widget_ext.rs
+++ b/src/widget_ext.rs
@@ -3,7 +3,7 @@ use druid::widget::{ControllerHost, LabelText};
 use druid::{Point, Selector, WidgetExt as _, WindowHandle};
 
 use crate::on_cmd::OnCmd;
-use crate::stack_tooltip::{StackTooltip, ADVISE_TOOLTIP_SHOW, CANCEL_TOOLTIP_SHOW};
+use crate::stack_tooltip::{StackTooltip, ADVISE_TOOLTIP_SHOW, CANCEL_TOOLTIP_SHOW, PlainOrRich};
 use crate::tooltip::TooltipState;
 use crate::{OnChange, OnMonitor, TooltipController};
 
@@ -57,7 +57,7 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     }
 
     /// Open a stack based tooltip when the mouse is hovered over this widget
-    fn stack_tooltip(self, label: impl Into<LabelText<T>>) -> StackTooltip<T> {
+    fn stack_tooltip(self, label: impl Into<PlainOrRich>) -> StackTooltip<T> {
         StackTooltip::new(self, label)
     }
 }


### PR DESCRIPTION
Round 3 of Stack based Tooltips

The biggest things here is that it utilises z-index painting to ensure that tooltips always render over surrounding widgets.

Also adds a wealth of customization options, allowing you to set modify the appearance of the tooltip text as flexibly as you would the RichText widget (the API is only slightly rougher than the regular Label - if you've used RichText it's almost exactly the same), You can also set the background colour, border width and border color.