### PR TITLE
Standardize copyright headers.

### DIFF
--- a/.github/copyright.sh
+++ b/.github/copyright.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# If there are new files with headers that can't match the conditions here,
+# then the files can be ignored by an additional glob argument via the -g flag.
+# For example:
+#   -g "!src/special_file.rs"
+#   -g "!src/special_directory"
+
+# Check all the standard Rust source files
+output=$(rg "^// Copyright (19|20)[\d]{2} (.+ and )?the Druid Authors( and .+)?$\n^// SPDX-License-Identifier: Apache-2\.0 OR MIT$\n\n" --files-without-match --multiline -g "*.rs" .)
+
+if [ -n "$output" ]; then
+	echo -e "The following files lack the correct copyright header:\n"
+	echo $output
+	echo -e "\n\nPlease add the following header:\n"
+	echo "// Copyright $(date +%Y) the Druid Authors"
+	echo "// SPDX-License-Identifier: Apache-2.0 OR MIT"
+	echo -e "\n... rest of the file ...\n"
+	exit 1
+fi
+
+echo "All files have correct copyright headers."
+exit 0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,10 @@ jobs:
     - name: Install deps
       run: |
         sudo apt-get update
-        sudo apt-get install libgtk-3-dev
+        sudo apt-get install libgtk-3-dev ripgrep
+
+    - name: Check copyright headers
+      run: bash .github/copyright.sh
 
     - name: Install stable toolchain
       uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Extra widgets for `druid` that are not yet ready for inclusion in
 version = "0.1.0"
 authors = ["Richard Dodd <richard.o.dodd@gmail.com>"]
 edition = "2018"
-license = "MIT OR Apache-2.0"
+license = "Apache-2.0 OR MIT"
 
 [features]
 async = ["tokio/rt", "futures", "flume"]

--- a/druid-widget-nursery-derive/Cargo.toml
+++ b/druid-widget-nursery-derive/Cargo.toml
@@ -3,7 +3,7 @@ name = "druid-widget-nursery-derive"
 description = "A proc-macro helper library for `druid-widget-nursery`"
 version = "0.1.0"
 edition = "2021"
-license = "MIT/Apache-2.0"
+license = "Apache-2.0 OR MIT"
 
 [lib]
 proc-macro = true

--- a/druid-widget-nursery-derive/src/lib.rs
+++ b/druid-widget-nursery-derive/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2022 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 

--- a/druid-widget-nursery-derive/src/prism.rs
+++ b/druid-widget-nursery-derive/src/prism.rs
@@ -1,3 +1,6 @@
+// Copyright 2022 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{parse_quote, spanned::Spanned, Data, DeriveInput, Fields, GenericParam, WherePredicate};

--- a/examples/advanced_slider_demo.rs
+++ b/examples/advanced_slider_demo.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::widget::{Flex, Slider};
 use druid::{AppLauncher, Color, Widget, WidgetExt, WindowDesc};
 use druid_widget_nursery::AdvancedSlider;

--- a/examples/animated_value.rs
+++ b/examples/animated_value.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::{
     AppLauncher, BoxConstraints, Color, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx,
     PaintCtx, RenderContext, Size, UnitPoint, UpdateCtx, Widget, WidgetExt, WindowDesc,

--- a/examples/animation-curves.rs
+++ b/examples/animation-curves.rs
@@ -1,18 +1,5 @@
-// Copyright 2022 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// Author: Dietmar Maurer <dietmar@proxmox.com>
+// Copyright 2022 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use druid::kurbo::{BezPath, Circle, Line};
 use druid::piet::{LineCap, LineJoin, RenderContext, StrokeStyle};

--- a/examples/animator.rs
+++ b/examples/animator.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::kurbo::{Circle, Point, Size};
 use druid::widget::{
     Button, CrossAxisAlignment, Flex, Label, LabelText, RadioGroup, TextBox, WidgetExt,

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -1,16 +1,5 @@
-// Copyright 2019 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2019 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use std::time::Duration;
 

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::lens::Map;
 use druid::widget::{Button, Flex, Label, LabelText, Split, TextBox};
 use druid::{AppLauncher, Data, Env, Lens, Point, Size, Widget, WidgetExt, WindowDesc};

--- a/examples/dropdown.rs
+++ b/examples/dropdown.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::widget::{
     Button, CrossAxisAlignment, Flex, Label, RadioGroup, Scroll, TextBox, WidgetExt,
 };

--- a/examples/dynamic_sized_box.rs
+++ b/examples/dynamic_sized_box.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::{
     widget::{Flex, Label, LineBreaking, MainAxisAlignment, SizedBox},
     AppLauncher, Color, Data, Env, Lens, Widget, WidgetExt, WindowDesc,

--- a/examples/file_manager.rs
+++ b/examples/file_manager.rs
@@ -1,16 +1,5 @@
-// Copyright 2019 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2019 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! Demos advanced tree widget and tree manipulations.
 

--- a/examples/flex-table.rs
+++ b/examples/flex-table.rs
@@ -1,18 +1,5 @@
-// Copyright 2021 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// Author: Dietmar Maurer <dietmar@proxmox.com>
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use druid::widget::{
     Align, Container, CrossAxisAlignment, Flex, Label, Stepper, TextBox, WidgetExt,

--- a/examples/hot-reload/src/lib.rs
+++ b/examples/hot-reload/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::widget::{Flex, TextBox};
 use druid::{Data, Lens, Widget, WidgetExt};
 

--- a/examples/hot-reload/src/main.rs
+++ b/examples/hot-reload/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid_widget_nursery::hot_reload::{AppLauncher, WindowDesc};
 use hot_reload::AppData;
 

--- a/examples/json_viewer.rs
+++ b/examples/json_viewer.rs
@@ -1,16 +1,5 @@
-// Copyright 2019 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2019 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! A json viewer using the tree widget
 use std::{

--- a/examples/mask.rs
+++ b/examples/mask.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2022 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use druid::widget::{Button, Flex, TextBox};
 use druid::{AppLauncher, Color, Data, Lens, Widget, WidgetExt, WindowDesc, WindowSizePolicy};

--- a/examples/material_icons.rs
+++ b/examples/material_icons.rs
@@ -1,3 +1,6 @@
+// Copyright 2022 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::{widget::Flex, AppLauncher, Color, LocalizedString, Widget, WidgetExt, WindowDesc};
 use druid_widget_nursery::material_icons::{
     normal::action::{ABC, ADD_CARD, ADD_TASK, ADD_TO_DRIVE},

--- a/examples/navigator.rs
+++ b/examples/navigator.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::sync::Arc;
 
 use druid::{

--- a/examples/partial.rs
+++ b/examples/partial.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::widget::{Flex, Radio, TextBox};
 use druid::{AppLauncher, Data, UnitPoint, Widget, WidgetExt, WindowDesc};
 use druid_widget_nursery::prism::{Closures, DisablePrismWrap};

--- a/examples/prisms.rs
+++ b/examples/prisms.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::widget::{CrossAxisAlignment, Flex, Slider, TextBox};
 use druid::{AppLauncher, Data, UnitPoint, Widget, WidgetExt, WindowDesc};
 use druid_widget_nursery::prism::{Closures, Prism};

--- a/examples/progress_bar.rs
+++ b/examples/progress_bar.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::piet;
 use druid::piet::{Color, GradientStop, UnitPoint};
 use druid::widget::{Button, Flex, Label, WidgetExt};

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -1,16 +1,5 @@
-// Copyright 2019 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2019 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use druid::widget::{CrossAxisAlignment, Flex, Label, Scroll};
 use druid::{AppLauncher, Data, Env, Insets, Lens, Widget, WidgetExt, WindowDesc};

--- a/examples/splits.rs
+++ b/examples/splits.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::im::Vector;
 use druid::widget::{Container, Flex, Label, Scroll, WidgetExt};
 use druid::{AppLauncher, Data, Env, Lens, Widget, WindowDesc};

--- a/examples/stack-containers.rs
+++ b/examples/stack-containers.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2022 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use druid::widget::{Container, Label};
 use druid::{AppLauncher, Color, Data, Lens, Widget, WidgetExt, WindowDesc};

--- a/examples/stack-fit.rs
+++ b/examples/stack-fit.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2022 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use druid::widget::{Container, Label};
 use druid::{AppLauncher, Color, Data, Lens, Widget, WidgetExt, WindowDesc};

--- a/examples/stack-gradient.rs
+++ b/examples/stack-gradient.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2022 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use druid::widget::{Align, Container, Label};
 use druid::{

--- a/examples/stack.rs
+++ b/examples/stack.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2022 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use druid::widget::{Container, Controller, Flex, Label, Slider, TextBox};
 use druid::{

--- a/examples/stack_tooltip.rs
+++ b/examples/stack_tooltip.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2022 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use druid::{
     widget::{Flex, Label},

--- a/examples/titlebar.rs
+++ b/examples/titlebar.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::widget::{Button, Flex, Label};
 use druid::{AppLauncher, Application, Widget, WidgetExt, WindowDesc};
 use druid_widget_nursery::TitleBar;

--- a/examples/todo_list.rs
+++ b/examples/todo_list.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::im::Vector;
 use druid::widget::{Button, Checkbox, CrossAxisAlignment, Flex, Label, List, Radio, TextBox};
 use druid::{AppLauncher, ArcStr, UnitPoint, Widget, WidgetExt};

--- a/examples/tooltip.rs
+++ b/examples/tooltip.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::{
     widget::{Flex, Label, TextBox},
     AppLauncher, Data, Env, Lens, Widget, WidgetExt, WindowDesc,

--- a/examples/tree.rs
+++ b/examples/tree.rs
@@ -1,16 +1,5 @@
-// Copyright 2019 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2019 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! Demos the most basic tree widget. See the file_manager example for a full demo.
 use std::fmt;

--- a/examples/wrap.rs
+++ b/examples/wrap.rs
@@ -1,16 +1,5 @@
-// Copyright 2019 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2019 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use druid::widget::prelude::*;
 use druid::widget::Label;

--- a/src/advanced_slider.rs
+++ b/src/advanced_slider.rs
@@ -1,16 +1,5 @@
-// Copyright 2021 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use ::std::time::Instant;
 

--- a/src/animation/animated_value.rs
+++ b/src/animation/animated_value.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2022 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use std::ops::Deref;
 

--- a/src/animation/animator.rs
+++ b/src/animation/animator.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use super::*;
 
 /// An animator. This keeps track of multiple running animations, and the dependencies between
@@ -81,10 +84,7 @@ impl Animator {
         event: AnimationEvent,
         id: AnimationId,
     ) {
-        self.pending_starts
-            .entry(event)
-            .or_insert_with(Vec::new)
-            .push(id);
+        self.pending_starts.entry(event).or_default().push(id);
         self.pending_count += 1;
     }
 

--- a/src/animation/context.rs
+++ b/src/animation/context.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use crate::animation::state::AnimationState;
 use crate::animation::*;
 

--- a/src/animation/controller.rs
+++ b/src/animation/controller.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2022 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use super::{AnimationDirection, AnimationStatus};
 

--- a/src/animation/curve.rs
+++ b/src/animation/curve.rs
@@ -1,16 +1,5 @@
-// Copyright 2019 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2019 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use std::f64::consts::PI;
 use std::fmt;

--- a/src/animation/interpolate.rs
+++ b/src/animation/interpolate.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2022 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use druid::{Color, Insets, Point, Rect, Size, Vec2};
 

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! Druid animation library
 
 mod animated_value;

--- a/src/animation/state.rs
+++ b/src/animation/state.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use crate::animation::*;
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/animation/storage.rs
+++ b/src/animation/storage.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::num::NonZeroU32;
 
 #[allow(clippy::upper_case_acronyms)]

--- a/src/animation/test.rs
+++ b/src/animation/test.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use super::*;
 
 #[test]

--- a/src/autofocus.rs
+++ b/src/autofocus.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::widget::prelude::*;
 use druid::{widget::Controller, Command, Selector};
 

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2020 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! A widget that allows for arbitrary layout of it's children.
 use druid::kurbo::Rect;

--- a/src/computed.rs
+++ b/src/computed.rs
@@ -1,16 +1,5 @@
-// Copyright 2021 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! Widget to dynamically compute data.
 //! It is like Label::dynamic but more general.

--- a/src/configure_env.rs
+++ b/src/configure_env.rs
@@ -1,3 +1,6 @@
+// Copyright 2022 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use crate::multi_value::INDENT;
 use druid::Env;
 

--- a/src/context_traits.rs
+++ b/src/context_traits.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::time::Duration;
 
 use druid::piet::PietText;

--- a/src/dropdown.rs
+++ b/src/dropdown.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::commands::CLOSE_WINDOW;
 use druid::widget::prelude::*;
 use druid::widget::Controller;

--- a/src/dropdown_select.rs
+++ b/src/dropdown_select.rs
@@ -1,16 +1,5 @@
-// Copyright 2019 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2019 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! A simple list selection widget, for selecting a single value out of a list.
 

--- a/src/dyn_lens.rs
+++ b/src/dyn_lens.rs
@@ -1,16 +1,5 @@
-// Copyright 2021 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! A version of Lens that can be made into a trait object
 

--- a/src/dynamic_sized_box.rs
+++ b/src/dynamic_sized_box.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::widget::prelude::*;
 use druid::Data;
 

--- a/src/enum_switcher.rs
+++ b/src/enum_switcher.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use crate::prism::{Prism, PrismWidget, PrismWrap};
 use druid::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, Size,

--- a/src/future_widget.rs
+++ b/src/future_widget.rs
@@ -1,16 +1,5 @@
-// Copyright 2018 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2018 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! widgets that can run async tasks
 

--- a/src/hot_reload/hot_reload_lib.rs
+++ b/src/hot_reload/hot_reload_lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use libloading::{Library, Symbol};
 use notify5::{Event, RecommendedWatcher, RecursiveMode, Watcher};
 use std::fs;

--- a/src/hot_reload/mod.rs
+++ b/src/hot_reload/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 // TODO: survive a change in AppData.
 
 use std::marker::PhantomData;

--- a/src/hot_reload/widget.rs
+++ b/src/hot_reload/widget.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use super::{hot_reload_lib::HotReloadLib, RELOAD};
 use druid::{widget::prelude::*, WidgetPod};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,5 @@
-// Copyright 2018 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2018 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! A collection of widgets for the druid GUI framework
 

--- a/src/list_filter.rs
+++ b/src/list_filter.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::im::Vector;
 use druid::widget::ListIter;
 use druid::{

--- a/src/list_select.rs
+++ b/src/list_select.rs
@@ -1,16 +1,5 @@
-// Copyright 2019 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2019 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! A simple list selection widget, for selecting a single value out of a list.
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 /// Generates `Selector`s based on module, line and column
 /// ```
 /// # use druid_widget_nursery::selectors;

--- a/src/mask.rs
+++ b/src/mask.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2022 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use druid::theme;
 use druid::widget::{Align, BackgroundBrush, Flex, Label, LabelText, Spinner};

--- a/src/material_icons.rs
+++ b/src/material_icons.rs
@@ -1,3 +1,6 @@
+// Copyright 2022 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 pub use druid_material_icons::{normal, IconPaths};
 
 use druid::{

--- a/src/multi_value.rs
+++ b/src/multi_value.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use crate::animation::{Animated, AnimationCurve, Interpolate};
 use crate::prism::{DisablePrismWrap, OptionSome, Prism};
 use druid::theme::WIDGET_PADDING_VERTICAL;

--- a/src/navigator.rs
+++ b/src/navigator.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::{cmp::Ordering, collections::HashMap, fmt, hash::Hash, unreachable};
 
 use druid::{widget::prelude::*, Point, WidgetPod};

--- a/src/on_change.rs
+++ b/src/on_change.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::widget::prelude::*;
 use druid::widget::Controller;
 

--- a/src/on_cmd.rs
+++ b/src/on_cmd.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::widget::prelude::*;
 use druid::widget::Controller;
 use druid::Selector;

--- a/src/on_monitor.rs
+++ b/src/on_monitor.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::widget::prelude::*;
 use druid::{Data, Point, Rect, Scalable, Screen, Vec2, WindowHandle};
 

--- a/src/prism.rs
+++ b/src/prism.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
     Point, Size, UpdateCtx, Widget, WidgetPod,

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -1,16 +1,5 @@
-// Copyright 2021 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! A modified progress bar widget demo. The goal here is to put more
 //! configuration on the control, using theme colours as defaults and

--- a/src/separator.rs
+++ b/src/separator.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2020 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! A separator widget.
 

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::cmp::Ordering;
 
 use druid::widget::{Axis, ListIter};

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2022 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use druid::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,

--- a/src/stack_tooltip.rs
+++ b/src/stack_tooltip.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2020 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! A stack based tooltip widget.
 

--- a/src/table/flex_table.rs
+++ b/src/table/flex_table.rs
@@ -1,18 +1,5 @@
-// Copyright 2021 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// Author: Dietmar Maurer <dietmar@proxmox.com>
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use druid::widget::BackgroundBrush;
 use druid::{

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -1,18 +1,5 @@
-// Copyright 2021 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// Author: Dietmar Maurer <dietmar@proxmox.com>
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use druid::{Data, Widget, WidgetPod};
 

--- a/src/table/table_column_width.rs
+++ b/src/table/table_column_width.rs
@@ -1,18 +1,5 @@
-// Copyright 2021 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// Author: Dietmar Maurer <dietmar@proxmox.com>
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use std::ops::Range;
 

--- a/src/theme_loader/mod.rs
+++ b/src/theme_loader/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! Loading themes from files.
 //!
 //! This module consists of two parts: A macro for declaring 'themes'

--- a/src/theme_loader/widget.rs
+++ b/src/theme_loader/widget.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::path::PathBuf;
 
 #[cfg(feature = "notify")]

--- a/src/titlebar.rs
+++ b/src/titlebar.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::{Data, Event, Widget};
 
 /// A TitleBar widget.

--- a/src/tooltip.rs
+++ b/src/tooltip.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::commands::CLOSE_WINDOW;
 use druid::widget::prelude::*;
 use druid::widget::{Controller, Label, LabelText};

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2020 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! A tree widget.
 

--- a/src/versioned.rs
+++ b/src/versioned.rs
@@ -1,16 +1,5 @@
-// Copyright 2021 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use std::ops;
 

--- a/src/wedge.rs
+++ b/src/wedge.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::kurbo::{BezPath, Size};
 use druid::piet::{LineCap, LineJoin, RenderContext, StrokeStyle};
 use druid::theme;

--- a/src/widget_ext.rs
+++ b/src/widget_ext.rs
@@ -1,3 +1,6 @@
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use druid::widget::prelude::*;
 use druid::widget::{ControllerHost, LabelText};
 use druid::{Point, Selector, WidgetExt as _, WindowHandle};

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -1,16 +1,5 @@
-// Copyright 2021 The Druid Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2021 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use druid::widget::prelude::*;
 use druid::widget::Axis;

--- a/tests/prism.rs
+++ b/tests/prism.rs
@@ -1,3 +1,6 @@
+// Copyright 2022 the Druid Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 #![cfg(feature = "derive")]
 
 use std::{fmt::Debug, marker::PhantomData};


### PR DESCRIPTION
The Linebender standard for copyright headers was decided last year in [kurbo#207](https://github.com/linebender/kurbo/issues/207) as the following:

```
// Copyright <year of file creation> the <Project> Authors
// SPDX-License-Identifier: Apache-2.0 OR MIT
```

This PR converts all file headers to this standard form.