### PR TITLE
Reimplement FlexTable to be reactive to data changes and synthesise cell widgets at runtime

### DIFF
--- a/examples/flex-table.rs
+++ b/examples/flex-table.rs
@@ -20,7 +20,7 @@ use druid::widget::{
 use druid::{theme, AppLauncher, Color, Data, Env, Lens, UnitPoint, Widget, WindowDesc};
 
 use druid_widget_nursery::table::{
-    FlexTable, TableCellVerticalAlignment, TableColumnWidth, TableRow,
+    FlexTable, FlexTableFixed, TableCellVerticalAlignment, TableColumnWidth, TableRow,
 };
 
 #[derive(Clone, Data, Default, Lens)]
@@ -33,41 +33,40 @@ struct DemoState {
 fn make_imput_form_example() -> impl Widget<DemoState> {
     use TableColumnWidth::*;
 
-    FlexTable::new()
+    FlexTableFixed::new()
         .inner_border(theme::BORDER_LIGHT, 1.)
         .with_column_width(Intrinsic)
         .with_column_width((Flex(1.), 100.))
-        .with_row(
-            TableRow::new()
-                .with_child(Label::new("Username:").align_horizontal(UnitPoint::RIGHT))
+        .with_row_auto(|row| {
+            row.with_child(Label::new("Username:").align_horizontal(UnitPoint::RIGHT))
                 .with_child(
                     TextBox::new()
                         .with_placeholder("Username")
                         .expand_width()
                         .lens(DemoState::input_username),
-                ),
-        )
-        .with_row(
-            TableRow::new()
-                .with_child(Label::new("Password:").align_horizontal(UnitPoint::RIGHT))
+                )
+        })
+        .with_row_auto(|row| {
+            row.with_child(Label::new("Password:").align_horizontal(UnitPoint::RIGHT))
                 .with_child(
                     TextBox::new()
                         .with_placeholder("Password")
                         .expand_width()
                         .lens(DemoState::input_password),
-                ),
-        )
+                )
+        })
+        .adapt()
         .border(Color::WHITE, 1.)
 }
 
 fn make_row_alignment_example() -> impl Widget<DemoState> {
-    let mut table = FlexTable::new()
+    let mut table = FlexTableFixed::new()
         .inner_border(theme::BORDER_LIGHT, 1.)
         .default_column_width(TableColumnWidth::Intrinsic);
 
     use TableCellVerticalAlignment::*;
 
-    let mut row = TableRow::new().vertical_alignment(Baseline);
+    let mut row = TableRow::new(0).vertical_alignment(Baseline);
 
     row.add_child(Label::new("Baseline"));
 
@@ -93,7 +92,7 @@ fn make_row_alignment_example() -> impl Widget<DemoState> {
     table.add_row(row);
 
     for align in [Bottom, Middle, Top, Fill] {
-        let mut row = TableRow::new().min_height(40.).vertical_alignment(align);
+        let mut row = TableRow::new(1).min_height(40.).vertical_alignment(align);
 
         row.add_child(
             Label::new(format!("{align:?}"))
@@ -120,7 +119,7 @@ fn make_row_alignment_example() -> impl Widget<DemoState> {
         table.add_row(row);
     }
 
-    table.border(Color::WHITE, 1.)
+    table.adapt().border(Color::WHITE, 1.)
 }
 
 fn make_cell_alignment_example() -> impl Widget<DemoState> {
@@ -136,7 +135,7 @@ fn make_cell_alignment_example() -> impl Widget<DemoState> {
         UnitPoint::CENTER,
     ];
 
-    let mut row = TableRow::new().min_height(40.);
+    let mut row = TableRow::new(0).min_height(40.);
 
     for (i, alignment) in alignments.iter().enumerate() {
         row.add_child(
@@ -157,6 +156,7 @@ fn make_cell_alignment_example() -> impl Widget<DemoState> {
     FlexTable::new()
         .inner_border(theme::BORDER_LIGHT, 1.)
         .with_row(row)
+        .adapt()
         .border(Color::WHITE, 1.)
         .fix_height(42.)
 }

--- a/src/table/table_data.rs
+++ b/src/table/table_data.rs
@@ -1,0 +1,140 @@
+use std::{
+    cell::RefCell,
+    fmt::Debug,
+    hash::Hash,
+    ops::{Deref, Index, IndexMut},
+    sync::Arc,
+};
+
+use druid::{
+    lens::{Identity, InArc},
+    Data, Lens, Widget, WidgetExt,
+};
+
+use self::private::Sealed;
+
+use super::FlexTable;
+
+pub trait RowData: Data {
+    type Id: Hash + Eq + Clone + Debug;
+    type Column: Hash + Eq;
+
+    fn id(&self) -> Self::Id;
+
+    fn cell(&self, column: &Self::Column) -> Box<dyn Widget<Self>>;
+}
+
+impl<T: RowData> RowData for Arc<T> {
+    type Id = T::Id;
+    type Column = T::Column;
+
+    fn id(&self) -> Self::Id {
+        self.deref().id()
+    }
+
+    fn cell(&self, column: &Self::Column) -> Box<dyn Widget<Self>> {
+        self.deref()
+            .cell(column)
+            .lens(InArc::new::<T, T>(Identity))
+            .boxed()
+    }
+}
+
+pub(super) mod private {
+    pub enum Local {}
+
+    pub trait Sealed {}
+
+    impl Sealed for Local {}
+}
+
+pub trait TableData:
+    Data
+    + for<'a> Index<&'a <Self::Row as RowData>::Id, Output = Self::Row>
+    + for<'a> IndexMut<&'a <Self::Row as RowData>::Id, Output = Self::Row>
+{
+    type Row: RowData<Column = Self::Column>;
+    type Column: Hash + Eq + Clone;
+
+    fn keys(&self) -> impl Iterator<Item = <Self::Row as RowData>::Id>;
+
+    fn columns(&self) -> impl Iterator<Item = Self::Column>;
+
+    #[doc(hidden)]
+    fn _or_fixed<T: Sealed>(&self, _table: &FlexTable<Self>) -> &Self {
+        self
+    }
+}
+
+#[derive(Clone, Data, Default, Lens)]
+pub struct FixedRow<T: Data> {
+    data: T,
+}
+
+impl<T: Data> FixedTable<T> {
+    pub fn new(data: T) -> Self {
+        Self {
+            dummy: FixedRow {
+                data,
+            },
+            columns: Default::default(),
+            len: Default::default(),
+        }
+    }
+}
+
+impl<T: Data> RowData for FixedRow<T> {
+    type Id = usize;
+    type Column = usize;
+
+    fn id(&self) -> Self::Id {
+        0
+    }
+
+    fn cell(&self, _: &Self::Column) -> Box<dyn Widget<Self>> {
+        unimplemented!()
+    }
+}
+
+#[derive(Clone, Data, Default, Lens)]
+pub struct FixedTable<T: Data> {
+    dummy: FixedRow<T>,
+    #[data(ignore)]
+    len: RefCell<usize>,
+    #[data(ignore)]
+    columns: RefCell<usize>,
+}
+
+impl<T: Data> Index<&usize> for FixedTable<T> {
+    type Output = FixedRow<T>;
+
+    fn index(&self, _: &usize) -> &Self::Output {
+        &self.dummy
+    }
+}
+
+impl<T: Data> IndexMut<&usize> for FixedTable<T> {
+    fn index_mut(&mut self, _: &usize) -> &mut Self::Output {
+        &mut self.dummy
+    }
+}
+
+impl<T: Data> TableData for FixedTable<T> {
+    type Row = FixedRow<T>;
+    type Column = <Self::Row as RowData>::Column;
+
+    fn keys(&self) -> impl Iterator<Item = <Self::Row as RowData>::Id> {
+        0..*self.len.borrow()
+    }
+
+    fn columns(&self) -> impl Iterator<Item = Self::Column> {
+        0..*self.columns.borrow()
+    }
+
+    fn _or_fixed<U: Sealed>(&self, table: &FlexTable<Self>) -> &Self {
+        *self.columns.borrow_mut() = table.column_count();
+        *self.len.borrow_mut() = table.rows().count();
+
+        self
+    }
+}


### PR DESCRIPTION
This PR reworks FlexTable to operate similarly to List.

We introduce two new traits similar to ListIter: TableData and RowData, both of which have Data as a supertrait. FlexTable is now only implemented over types implementing TableData.

The required methods of TableData are such that we can trivially implement a FlexTable over a simple continuous container that will display all rows and cells constantly. However, they also allow us the flexibility to arbitrarily change the order of rows based on the underlying data, or to choose not to render rows - both by changing what is actually returned by the `keys` method.

Widgets are generated by calling on the `cell` method of RowData - as it is not a significant design burden a reference to the implementing data structure is provided so that the generated Widget can include constants derived from the current state of the data if it so chooses.

Some compromises are made to preserve the existing "fixed" functionality, where all rows and cells are provided up front. This is reimplemented in the FixedTable and FixedRow data types.