### PR TITLE
Add Widget derive macro

### DIFF
--- a/druid-widget-nursery-derive/Cargo.toml
+++ b/druid-widget-nursery-derive/Cargo.toml
@@ -12,3 +12,4 @@ proc-macro = true
 proc-macro2 = "1.0.36"
 quote = "1.0.14"
 syn = "1.0.85"
+syn2 = { package = "syn", version = "2" }

--- a/druid-widget-nursery-derive/src/lib.rs
+++ b/druid-widget-nursery-derive/src/lib.rs
@@ -3,6 +3,8 @@ use syn::{parse_macro_input, DeriveInput};
 
 mod prism;
 use prism::expand_prism;
+mod widget;
+use widget::expand_widget;
 
 #[proc_macro_derive(Prism)]
 pub fn prism(input: TokenStream) -> TokenStream {
@@ -10,4 +12,9 @@ pub fn prism(input: TokenStream) -> TokenStream {
     expand_prism(input)
         .unwrap_or_else(syn::Error::into_compile_error)
         .into()
+}
+
+#[proc_macro_derive(Widget, attributes(widget))]
+pub fn widget(input: TokenStream) -> TokenStream {
+    expand_widget(input)
 }

--- a/druid-widget-nursery-derive/src/widget.rs
+++ b/druid-widget-nursery-derive/src/widget.rs
@@ -1,0 +1,146 @@
+use proc_macro::TokenStream;
+use quote::{quote, ToTokens};
+use syn2::{
+  parse_macro_input, parse_quote, punctuated::Punctuated, DeriveInput, Expr, Meta, Token,
+  TypeParam,
+};
+
+pub fn expand_widget(input: TokenStream) -> TokenStream {
+    let DeriveInput {
+        ident,
+        attrs,
+        mut generics,
+        ..
+    } = parse_macro_input!(input);
+
+    let data_bound: TypeParam = parse_quote!(T: Clone + druid::Data);
+    let widget_bound: TypeParam = parse_quote!(W: Widget<T>);
+    generics
+        .type_params_mut()
+        .find(|param| param.ident.to_string() == "T")
+        .unwrap()
+        .bounds
+        .extend(data_bound.bounds);
+    generics
+        .type_params_mut()
+        .find(|param| param.ident.to_string() == "W")
+        .unwrap()
+        .bounds
+        .extend(widget_bound.bounds);
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let mut event = None;
+    let mut lifecycle = None;
+    let mut update = None;
+    let mut layout = None;
+    let mut paint = None;
+    let mut widget_pod = None;
+
+    let list = &attrs[0].meta.require_list().unwrap();
+    assert!(list.path.is_ident("widget"));
+    let args = list
+        .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+        .unwrap();
+
+    for args in args {
+        let name_val = args.require_name_value().unwrap();
+
+        let value = match &name_val.value {
+            Expr::Path(expr_path) => {
+                let ident = expr_path.path.require_ident().unwrap();
+                ident.to_token_stream()
+            }
+            Expr::Lit(lit) => lit.to_token_stream(),
+            _ => panic!(
+                "Must be literal naming a method on Self {:?}",
+                name_val.value
+            ),
+        };
+
+        match &name_val.path {
+            path if path.is_ident("event") => {
+                if value.to_string() == "event" {
+                    panic!("`event` method implementation cannot be named `event`")
+                }
+                event = Some(quote! {self.#value(ctx, event, data, env)})
+            }
+            path if path.is_ident("lifecycle") => {
+                if value.to_string() == "lifecycle" {
+                    panic!("`lifecycle` method implementation cannot be named `lifecycle`")
+                }
+                lifecycle = Some(quote! {self.#value(ctx, event, data, env)})
+            }
+            path if path.is_ident("update") => {
+                if value.to_string() == "update" {
+                    panic!("`update` method implementation cannot be named `update`")
+                }
+                update = Some(quote! {self.#value(ctx, old_data, data, env)})
+            }
+            path if path.is_ident("layout") => {
+                if value.to_string() == "layout" {
+                    panic!("`layout` method implementation cannot be named `layout`")
+                }
+                layout = Some(quote! {self.#value(ctx, bc, data, env)})
+            }
+            path if path.is_ident("paint") => {
+                if value.to_string() == "paint" {
+                    panic!("`paint` method implementation cannot be named `paint`")
+                }
+                paint = Some(quote! {self.#value(ctx, data, env)})
+            }
+            path if path.is_ident("widget_pod") => widget_pod = Some(quote! {self.#value}),
+            _ => panic!("Must be one of `event`, `lifecycle`, `update`, `layout` or `paint`."),
+        };
+    }
+
+    let widget_pod = widget_pod.unwrap_or_else(|| quote! {"self.widget_pod"});
+    let event = event.unwrap_or_else(|| {
+        quote! {
+          #widget_pod.event(ctx, event, data, env)
+        }
+    });
+    let lifecycle = lifecycle.unwrap_or_else(|| {
+        quote! {
+          #widget_pod.lifecycle(ctx, event, data, env)
+        }
+    });
+    let update = update.unwrap_or_else(|| {
+        quote! {
+          #widget_pod.update(ctx, data, env)
+        }
+    });
+    let layout = layout.unwrap_or_else(|| {
+        quote! {
+          #widget_pod.layout(ctx, bc, data, env)
+        }
+    });
+    let paint = paint.unwrap_or_else(|| {
+        quote! {
+          #widget_pod.paint(ctx, data, env)
+        }
+    });
+
+    quote! {
+    impl #impl_generics druid::Widget<T> for #ident #ty_generics #where_clause {
+      fn event(&mut self, ctx: &mut druid::EventCtx, event: &druid::Event, data: &mut T, env: &druid::Env) {
+        #event
+      }
+
+      fn lifecycle(&mut self, ctx: &mut druid::LifeCycleCtx, event: &druid::LifeCycle, data: &T, env: &druid::Env) {
+        #lifecycle
+      }
+
+      fn update(&mut self, ctx: &mut druid::UpdateCtx, old_data: &T, data: &T, env: &druid::Env) {
+        #update
+      }
+
+      fn layout(&mut self, ctx: &mut druid::LayoutCtx, bc: &druid::BoxConstraints, data: &T, env: &druid::Env) -> druid::Size {
+        #layout
+      }
+
+      fn paint(&mut self, ctx: &mut druid::PaintCtx, data: &T, env: &druid::Env) {
+        #paint
+      }
+    }
+  }.into()
+}

--- a/examples/derive_widget.rs
+++ b/examples/derive_widget.rs
@@ -1,0 +1,69 @@
+use druid::{
+    widget::{Button, Flex, Label},
+    AppLauncher, Data, Env, Lens, PaintCtx, UpdateCtx, Widget, WidgetExt,
+    WidgetPod, WindowDesc, WindowSizePolicy,
+};
+
+#[cfg(feature = "derive")]
+pub use druid_widget_nursery_derive::Widget;
+
+#[derive(Widget)]
+#[widget(widget_pod = 1, paint = paint_impl, update = update_impl)]
+pub struct InvisibleIf<T, W>(Box<dyn Fn(&T) -> bool>, WidgetPod<T, W>);
+
+impl<T: Data, W: Widget<T>> InvisibleIf<T, W> {
+    pub fn new(test: impl Fn(&T) -> bool + 'static, widget: W) -> Self {
+        Self(Box::new(test), WidgetPod::new(widget))
+    }
+
+    fn paint_impl(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
+        if !self.0(data) {
+            self.1.paint(ctx, data, env)
+        }
+    }
+
+    fn update_impl(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
+        if !old_data.same(data) {
+            ctx.request_paint()
+        }
+        self.1.update(ctx, data, env)
+    }
+}
+
+#[derive(Clone, Data, Lens)]
+struct AppState {
+    render_widget: bool,
+}
+
+fn ui_builder() -> impl Widget<AppState> {
+    Flex::column()
+        .with_child(
+            Button::new("Toggle render")
+                .on_click(|_, data: &mut AppState, _| {
+                    data.render_widget = !data.render_widget;
+                })
+                .padding(5.),
+        )
+        .with_child(
+            InvisibleIf::new(
+                |data: &AppState| !data.render_widget,
+                Label::new("Rendered"),
+            )
+            .padding(10.),
+        )
+}
+
+pub fn main() {
+    let main_window = WindowDesc::new(ui_builder())
+        .window_size_policy(WindowSizePolicy::Content)
+        .title("Load Widget Derive example");
+
+    let state = AppState {
+        render_widget: true,
+    };
+
+    AppLauncher::with_window(main_window)
+        .log_to_console()
+        .launch(state)
+        .expect("launch failed");
+}


### PR DESCRIPTION
This PR adds a new derive macro for implementing Widget automatically on a struct.

By default the macro assumes the struct has a `WidgetPod` field named `widget_pod` and forwards all `Widget` trait methods to the `WidgetPod`'s implementation. In the case a user chooses not to have a child widget, they need only provide implementations for all the required `Widget` methods. The user can also choose to name a different field as containing the `WidgetPod`.

As in the example, this behaviour can be mixed and matched, with the named `WidgetPod` having some methods forwarded to it, with other method implementations "overridden" in the provided method implementations on the struct.

Open issues:

- [ ] The macro's handling of generics is currently quite fragile, assuming the name of the generic implementing `Data` is `T` and the name of the generic implementing `Widget` is `W`. It does try to handle any additional bounds on the `Data` type.